### PR TITLE
extended Microsoft Graph X-Ray to generate Terraform msgraph resources

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="905841bc-b970-4f37-8270-94d54247f5e5" name="Changes" comment="" />
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="ProjectColorInfo"><![CDATA[{
+  "associatedIndex": 6
+}]]></component>
+  <component name="ProjectId" id="3FKA1cN5l6kWMa65pORB07KYP1z" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "ModuleVcsDetector.initialDetectionPerformed": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.git.unshallow": "true",
+    "git-widget-placeholder": "feature/review-and-fix-tests",
+    "last_opened_file_path": "C:/dev/mjendza/graphxray",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "npm.test.executor": "Run",
+    "vue.rearranger.settings.migration": "true"
+  }
+}]]></component>
+  <component name="RunManager">
+    <configuration name="test" type="js.build_tools.npm" temporary="true" nameIsGenerated="true">
+      <package-json value="$PROJECT_DIR$/package.json" />
+      <command value="run" />
+      <scripts>
+        <script value="test" />
+      </scripts>
+      <node-interpreter value="project" />
+      <envs />
+      <method v="2" />
+    </configuration>
+    <recent_temporary>
+      <list>
+        <item itemvalue="npm.test" />
+      </list>
+    </recent_temporary>
+  </component>
+  <component name="SharedIndexes">
+    <attachedChunks>
+      <set>
+        <option value="bundled-js-predefined-d6986cc7102b-3aa1da707db6-JavaScript-WS-252.26830.93" />
+      </set>
+    </attachedChunks>
+  </component>
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="905841bc-b970-4f37-8270-94d54247f5e5" name="Changes" comment="" />
+      <created>1781813172503</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1781813172503</updated>
+      <workItem from="1781813173633" duration="1171000" />
+    </task>
+    <servers />
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+</project>

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
   "scripts": {
     "start": "node --openssl-legacy-provider scripts/start.js",
     "build": "node --openssl-legacy-provider scripts/build.js",
+    "build:dev": "node --openssl-legacy-provider scripts/build-dev.js",
     "build:firefox": "node --openssl-legacy-provider scripts/build-firefox.js",
     "test": "node scripts/test.js"
   },

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
       "<rootDir>/src/**/*.{spec,test}.{js,jsx,ts,tsx}"
     ],
     "testEnvironment": "jsdom",
-    "testRunner": "C:\\Users\\dhruvmu\\Projects\\EffortCounter\\EffortCounter.BrowserExtension\\node_modules\\jest-circus\\runner.js",
+    "testRunner": "jest-circus/runner",
     "transform": {
       "^.+\\.(js|jsx|mjs|cjs|ts|tsx)$": "<rootDir>/config/jest/babelTransform.js",
       "^.+\\.css$": "<rootDir>/config/jest/cssTransform.js",
@@ -145,6 +145,7 @@
     "modulePaths": [],
     "moduleNameMapper": {
       "^react-native$": "react-native-web",
+      "^@fluentui/([^/]+)/lib/(.*)$": "@fluentui/$1/lib-commonjs/$2",
       "^.+\\.module\\.(css|sass|scss)$": "identity-obj-proxy"
     },
     "moduleFileExtensions": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graph-x-ray",
-  "version": "1.1.10",
+  "version": "1.2.10",
   "private": true,
   "license": "AGPL-3.0-only",
   "dependencies": {

--- a/public/manifest.firefox.json
+++ b/public/manifest.firefox.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "version": "1.1.10",
+  "version": "1.2.10",
   "name": "Graph X-Ray",
   "short_name": "Graph X-Ray",
   "description": "Graph X-Ray converts your Microsoft admin portal clicks into ready-to-use code in PowerShell, C#, Python, and more.",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 3,
-  "version": "1.1.10",
+  "version": "1.2.10",
   "short_name": "Graph X-Ray",
   "name": "Graph X-Ray",
   "description": "Graph X-Ray converts your Microsoft admin portal clicks into ready-to-use code in PowerShell, C#, Python, and more.",

--- a/scripts/build-dev.js
+++ b/scripts/build-dev.js
@@ -1,0 +1,9 @@
+'use strict';
+
+// Dedicated DEV build. Mark this as a DEV build before the real build reads the
+// environment, then delegate to the standard production build. The flag is
+// injected into the bundle via DefinePlugin (header "DEV Build" badge) and read
+// again in build.js to append a "(DEV)" suffix to the extension manifest name.
+process.env.REACT_APP_DEV_BUILD = 'true';
+
+require('./build.js');

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -24,7 +24,7 @@ const configFactory = require('../config/webpack.config');
 const paths = require('../config/paths');
 // Use local helper to avoid deprecated fs.F_OK usage in older react-dev-utils.
 const checkRequiredFiles = require('./utils/checkRequiredFiles');
-const { createFirefoxManifest } = require('./utils/manifestBuilder');
+const { createFirefoxManifest, applyDevManifestLabel } = require('./utils/manifestBuilder');
 const formatWebpackMessages = require('react-dev-utils/formatWebpackMessages');
 const printHostingInstructions = require('react-dev-utils/printHostingInstructions');
 const FileSizeReporter = require('react-dev-utils/FileSizeReporter');
@@ -79,6 +79,12 @@ checkBrowsers(paths.appPath, isInteractive)
     // Merge with the public folder
     const copyPublicFolder = require('./utils/copyPublicFolder');
     copyPublicFolder(paths.appBuild);
+    // DEV build: append "(DEV)" to the extension manifest names. Done before the
+    // Firefox build folder is derived (createFirefoxBuildFolder), so Firefox
+    // inherits the suffix from this Chromium manifest.
+    if (process.env.REACT_APP_DEV_BUILD === 'true') {
+      applyDevManifestLabel(path.join(paths.appBuild, 'manifest.json'));
+    }
     // Start the webpack build
     return build(previousFileSizes);
   })

--- a/scripts/utils/manifestBuilder.js
+++ b/scripts/utils/manifestBuilder.js
@@ -54,6 +54,32 @@ function createFirefoxManifest({
   return firefoxManifest;
 }
 
+// Append a suffix (e.g. " (DEV)") to the extension's display names so a DEV build
+// is distinguishable from production and can be installed alongside it. Mutates
+// the manifest file in place. Safe to call on the Chromium MV3 manifest before
+// the Firefox manifest is derived from it, so both builds inherit the suffix.
+function applyDevManifestLabel(manifestPath, suffix = ' (DEV)') {
+  const manifest = fs.readJsonSync(manifestPath);
+
+  if (typeof manifest.name === 'string') {
+    manifest.name += suffix;
+  }
+  if (typeof manifest.short_name === 'string') {
+    manifest.short_name += suffix;
+  }
+  if (manifest.action && typeof manifest.action.default_title === 'string') {
+    manifest.action.default_title += suffix;
+  }
+  // Firefox MV2 keeps the action under browser_action.
+  if (manifest.browser_action && typeof manifest.browser_action.default_title === 'string') {
+    manifest.browser_action.default_title += suffix;
+  }
+
+  fs.writeJsonSync(manifestPath, manifest, { spaces: 2 });
+  return manifest;
+}
+
 module.exports = {
   createFirefoxManifest,
+  applyDevManifestLabel,
 };

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,50 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import App from "./App";
+import {
+  getCurrentMetrics,
+  getIsActive,
+  getStack,
+} from "./common/storage.js";
 
-test("renders learn react link", () => {
+// App polls storage on an interval and reads the cross-browser API on mount.
+// Stub those so the component can render in isolation under jsdom.
+jest.mock("./common/storage.js", () => ({
+  saveObjectInLocalStorage: jest.fn(),
+  getIsActive: jest.fn(),
+  getCurrentMetrics: jest.fn(),
+  getStack: jest.fn(),
+}));
+
+beforeEach(() => {
+  // resetMocks clears implementations between tests, so (re)configure here.
+  getIsActive.mockResolvedValue(false);
+  getCurrentMetrics.mockResolvedValue({ urls: [], tabName: "" });
+  getStack.mockResolvedValue([]);
+  // addListener() reads window.chrome.webview; provide a minimal stub.
+  window.chrome = {};
+});
+
+test("renders the Graph call history section", () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  expect(screen.getByText(/Graph call history/i)).toBeInTheDocument();
+});
+
+test("renders the call-to-action button", () => {
+  render(<App />);
+  expect(
+    screen.getByRole("button", { name: /Show me how/i })
+  ).toBeInTheDocument();
+});
+
+test("polls metrics after the interval fires", async () => {
+  jest.useFakeTimers();
+  try {
+    render(<App />);
+    await act(async () => {
+      jest.advanceTimersByTime(600);
+    });
+    expect(getCurrentMetrics).toHaveBeenCalled();
+  } finally {
+    jest.useRealTimers();
+  }
 });

--- a/src/common/client.js
+++ b/src/common/client.js
@@ -100,6 +100,232 @@ function generateLocalPowerShellSnippet(method, url, body, options = {}) {
   return lines.join("\n");
 }
 
+const GUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const HCL_IDENT_REGEX = /^[A-Za-z_][A-Za-z0-9_-]*$/;
+const TF_READONLY_KEYS = new Set([
+  "id",
+  "createdDateTime",
+  "deletedDateTime",
+  "renewedDateTime",
+  "modifiedDateTime",
+]);
+// @odata annotations that are server-generated and should be stripped from a recreate template.
+// Anything not listed here (notably @odata.type discriminators and *@odata.bind references) is kept.
+const TF_STRIP_ODATA_SUFFIXES = [
+  "@odata.context",
+  "@odata.nextLink",
+  "@odata.deltaLink",
+  "@odata.count",
+  "@odata.id",
+  "@odata.editLink",
+  "@odata.readLink",
+  "@odata.etag",
+  "@odata.mediaEtag",
+  "@odata.mediaContentType",
+  "@odata.mediaReadLink",
+  "@odata.mediaEditLink",
+];
+const TF_COLLECTION_SINGULARS = {
+  groups: "group",
+  users: "user",
+  applications: "application",
+  servicePrincipals: "service_principal",
+  oauth2PermissionGrants: "oauth2_permission_grant",
+  appRoleAssignedTo: "app_role_assignment",
+  federatedIdentityCredentials: "federated_identity_credential",
+  devices: "device",
+  contacts: "contact",
+};
+
+function hashUrl(url) {
+  let h = 0;
+  for (let i = 0; i < url.length; i++) {
+    h = ((h << 5) - h + url.charCodeAt(i)) | 0;
+  }
+  return Math.abs(h).toString(36).slice(0, 6);
+}
+
+function sanitizeLabel(value) {
+  return String(value)
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function shouldStripOdataKey(key) {
+  return TF_STRIP_ODATA_SUFFIXES.some(
+    (suffix) => key === suffix || key.endsWith(suffix)
+  );
+}
+
+function stripReadOnlyFields(value, depth = 0) {
+  if (Array.isArray(value)) {
+    return value.map((item) => stripReadOnlyFields(item, depth + 1));
+  }
+  if (value !== null && typeof value === "object") {
+    const out = {};
+    for (const [k, v] of Object.entries(value)) {
+      if (shouldStripOdataKey(k)) continue;
+      if (depth === 0 && TF_READONLY_KEYS.has(k)) continue;
+      out[k] = stripReadOnlyFields(v, depth + 1);
+    }
+    return out;
+  }
+  return value;
+}
+
+function formatHclString(str) {
+  const escaped = String(str)
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r")
+    .replace(/\t/g, "\\t");
+  return `"${escaped}"`;
+}
+
+function formatHclValue(value, indent) {
+  if (value === null || value === undefined) return "null";
+  if (typeof value === "boolean") return value ? "true" : "false";
+  if (typeof value === "number") return String(value);
+  if (typeof value === "string") return formatHclString(value);
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) return "[]";
+    const inner = indent + "  ";
+    const items = value.map((v) => `${inner}${formatHclValue(v, inner)},`);
+    return `[\n${items.join("\n")}\n${indent}]`;
+  }
+
+  if (typeof value === "object") {
+    const entries = Object.entries(value);
+    if (entries.length === 0) return "{}";
+    const inner = indent + "  ";
+    const keyWidth = Math.max(
+      ...entries.map(([k]) => (HCL_IDENT_REGEX.test(k) ? k.length : k.length + 2))
+    );
+    const lines = entries.map(([k, v]) => {
+      const keyOut = HCL_IDENT_REGEX.test(k) ? k : formatHclString(k);
+      const pad = " ".repeat(Math.max(0, keyWidth - keyOut.length));
+      return `${inner}${keyOut}${pad} = ${formatHclValue(v, inner)}`;
+    });
+    return `{\n${lines.join("\n")}\n${indent}}`;
+  }
+
+  return formatHclString(String(value));
+}
+
+function normalizeTerraformUrl(url) {
+  const { path } = parseGraphUrl(url);
+  let trimmed = path.replace(/^\/+/, "").split("?")[0];
+
+  let apiVersion = null;
+  if (/^v1\.0\//i.test(trimmed)) {
+    trimmed = trimmed.replace(/^v1\.0\//i, "");
+  } else if (/^beta\//i.test(trimmed)) {
+    apiVersion = "beta";
+    trimmed = trimmed.replace(/^beta\//i, "");
+  }
+
+  const segments = trimmed.split("/").filter(Boolean);
+  if (segments.length > 1) {
+    const last = segments[segments.length - 1];
+    if (GUID_REGEX.test(last)) {
+      segments.pop();
+    }
+  }
+  return { url: segments.join("/"), apiVersion };
+}
+
+function leafCollectionName(normalizedUrl) {
+  const segments = normalizedUrl.split("/").filter((s) => s && !s.startsWith("$"));
+  for (let i = segments.length - 1; i >= 0; i--) {
+    if (!GUID_REGEX.test(segments[i])) return segments[i];
+  }
+  return "";
+}
+
+function buildResourceLabel(normalizedUrl, body, fallbackSeed) {
+  const collection = leafCollectionName(normalizedUrl);
+  const prefix = TF_COLLECTION_SINGULARS[collection] || sanitizeLabel(collection) || "resource";
+
+  const nameCandidates = ["displayName", "mailNickname", "userPrincipalName", "name"];
+  for (const key of nameCandidates) {
+    const raw = body && typeof body === "object" ? body[key] : null;
+    if (typeof raw === "string" && raw.trim()) {
+      const slug = sanitizeLabel(raw);
+      if (slug) return `${prefix}_${slug}`;
+    }
+  }
+  return `${prefix}_${hashUrl(fallbackSeed)}`;
+}
+
+function renderTerraformBlock(label, url, apiVersion, body) {
+  const lines = [];
+  lines.push(`resource "msgraph_resource" "${label}" {`);
+  lines.push(`  url = "${url}"`);
+  if (apiVersion) {
+    lines.push(`  api_version = "${apiVersion}"`);
+  }
+  lines.push(`  body = ${formatHclValue(body, "  ")}`);
+  lines.push(`}`);
+  return lines.join("\n");
+}
+
+function uniqueLabel(base, used) {
+  if (!used.has(base)) {
+    used.add(base);
+    return base;
+  }
+  let i = 2;
+  while (used.has(`${base}_${i}`)) i++;
+  const next = `${base}_${i}`;
+  used.add(next);
+  return next;
+}
+
+function tryParseJson(text) {
+  if (!text || typeof text !== "string") return null;
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+}
+
+function generateTerraformSnippet(method, url, requestBody, responseBody) {
+  const methodUpper = (method || "GET").toUpperCase();
+  if (methodUpper === "DELETE" || methodUpper === "OPTIONS") return null;
+
+  const source =
+    methodUpper === "GET" ? responseBody || requestBody : requestBody || responseBody;
+  const parsed = tryParseJson(source);
+  if (parsed === null || typeof parsed !== "object") return null;
+
+  const { url: normalizedUrl, apiVersion } = normalizeTerraformUrl(url);
+  if (!normalizedUrl) return null;
+
+  const used = new Set();
+  const items =
+    parsed && Array.isArray(parsed.value) ? parsed.value : [parsed];
+
+  const blocks = [];
+  items.forEach((item, idx) => {
+    if (!item || typeof item !== "object") return;
+    const cleaned = stripReadOnlyFields(item);
+    if (!cleaned || Object.keys(cleaned).length === 0) return;
+    const baseLabel = buildResourceLabel(normalizedUrl, item, `${url}#${idx}`);
+    const label = uniqueLabel(baseLabel, used);
+    blocks.push(renderTerraformBlock(label, normalizedUrl, apiVersion, cleaned));
+  });
+
+  if (blocks.length === 0) return null;
+  return blocks.join("\n\n");
+}
+
 async function getSnippetFromDevX(snippetLanguage, method, url, body, options = {}) {
   console.log("Get code snippet from DevX:", url, method);
 
@@ -108,6 +334,11 @@ async function getSnippetFromDevX(snippetLanguage, method, url, body, options = 
     const { host, path } = parseGraphUrl(url);
     const fullUrl = `https://${host}/${path.replace(/^\/+/, '')}`;
     return fullUrl;
+  }
+
+  // Terraform (msgraph): always generate locally, DevX has no Terraform support
+  if (snippetLanguage === "terraform") {
+    return generateTerraformSnippet(method, url, body ?? "", options.responseBody ?? "");
   }
 
   // PowerShell (Invoke-MgGraphRequest): always use local generation, never call DevX
@@ -445,14 +676,14 @@ const getCodeView = async function (
       baseUrl,
       options
     );
-    
+
     // Also generate a code snippet for the main batch request
     code = await getPowershellCmd(
       snippetLanguage,
       request.method,
       version + request.url,
       requestBody,
-      { ...options, includeConsistencyLevelHeader }
+      { ...options, includeConsistencyLevelHeader, responseBody: responseContent }
     );
   } else {
     // Regular single request
@@ -461,7 +692,7 @@ const getCodeView = async function (
       request.method,
       version + request.url,
       requestBody,
-      { ...options, includeConsistencyLevelHeader }
+      { ...options, includeConsistencyLevelHeader, responseBody: responseContent }
     );
   }
   
@@ -475,4 +706,4 @@ const getCodeView = async function (
   console.log("CodeView", codeView);
   return codeView;
 };
-export { getPowershellCmd, getRequestBody, getResponseContent, getCodeView, getBatchCodeSnippets, generateLocalPowerShellSnippet };
+export { getPowershellCmd, getRequestBody, getResponseContent, getCodeView, getBatchCodeSnippets, generateLocalPowerShellSnippet, generateTerraformSnippet };

--- a/src/common/client.js
+++ b/src/common/client.js
@@ -102,12 +102,27 @@ function generateLocalPowerShellSnippet(method, url, body, options = {}) {
 
 const GUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const HCL_IDENT_REGEX = /^[A-Za-z_][A-Za-z0-9_]*$/;
+// `id` is the resource identity — server-assigned, never a valid `body` input
+// for msgraph_resource, and captured separately for cross-resource references.
+// It is always stripped from the emitted body (regardless of source).
+const TF_ALWAYS_STRIP_TOP_KEYS = new Set(["id"]);
+
 const TF_READONLY_KEYS = new Set([
-  "id",
   "createdDateTime",
   "deletedDateTime",
   "renewedDateTime",
   "modifiedDateTime",
+  // Commonly server-generated/computed fields that break `terraform apply` if
+  // sent back in a create body. Kept conservative — only fields that are
+  // server-only across the common Entra resource types.
+  "appId",
+  "servicePrincipalType",
+  "publisherName",
+  "provisioningErrors",
+  "onPremisesSyncEnabled",
+  "onPremisesLastSyncDateTime",
+  "proxyAddresses",
+  "imAddresses",
 ]);
 
 const TF_STRIP_ODATA_SUFFIXES = [
@@ -158,16 +173,22 @@ function shouldStripOdataKey(key) {
   );
 }
 
-function stripReadOnlyFields(value, depth = 0) {
+function stripReadOnlyFields(value, depth = 0, opts = {}) {
+  // `@odata.*` annotations are always stripped (never valid in a request body).
+  // `TF_READONLY_KEYS` are stripped only for server-derived sources
+  // (stripReadOnlyKeys defaults to true); a user-authored create request body
+  // is trusted and passes stripReadOnlyKeys: false to keep its fields intact.
+  const stripReadOnlyKeys = opts.stripReadOnlyKeys !== false;
   if (Array.isArray(value)) {
-    return value.map((item) => stripReadOnlyFields(item, depth + 1));
+    return value.map((item) => stripReadOnlyFields(item, depth + 1, opts));
   }
   if (value !== null && typeof value === "object") {
     const out = {};
     for (const [k, v] of Object.entries(value)) {
       if (shouldStripOdataKey(k)) continue;
-      if (depth === 0 && TF_READONLY_KEYS.has(k)) continue;
-      out[k] = stripReadOnlyFields(v, depth + 1);
+      if (depth === 0 && TF_ALWAYS_STRIP_TOP_KEYS.has(k)) continue;
+      if (depth === 0 && stripReadOnlyKeys && TF_READONLY_KEYS.has(k)) continue;
+      out[k] = stripReadOnlyFields(v, depth + 1, opts);
     }
     return out;
   }
@@ -184,11 +205,20 @@ function formatHclString(str) {
   return `"${escaped}"`;
 }
 
+// Wrap a string so formatHclValue emits it verbatim (unquoted), e.g. a
+// Terraform reference like `msgraph_resource.group_x.id`.
+function rawHcl(expr) {
+  return { __hclRaw: String(expr) };
+}
+
 function formatHclValue(value, indent) {
   if (value === null || value === undefined) return "null";
   if (typeof value === "boolean") return value ? "true" : "false";
   if (typeof value === "number") return String(value);
   if (typeof value === "string") return formatHclString(value);
+  if (value && typeof value === "object" && typeof value.__hclRaw === "string") {
+    return value.__hclRaw;
+  }
 
   if (Array.isArray(value)) {
     if (value.length === 0) return "[]";
@@ -322,7 +352,76 @@ function parseODataContext(context) {
   return { url: fragment, apiVersion };
 }
 
-function generateLocalTerraformBatchSnippet(requestBody, responseBody) {
+const GUID_GLOBAL_REGEX = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi;
+
+// Rewrite literal GUIDs that match a resource emitted in the same snippet into
+// Terraform references, so generated blocks express their dependency graph:
+//   - a string that is exactly a known GUID  -> raw `msgraph_resource.<label>.id`
+//   - a GUID embedded in a string (e.g. an `*@odata.bind` URL) -> `${...}` interpolation
+// GUIDs not present in idToLabel are left untouched.
+function rewriteReferences(value, idToLabel) {
+  if (Array.isArray(value)) {
+    return value.map((v) => rewriteReferences(v, idToLabel));
+  }
+  if (value !== null && typeof value === "object") {
+    if (typeof value.__hclRaw === "string") return value; // already a raw expression
+    const out = {};
+    for (const [k, v] of Object.entries(value)) {
+      out[k] = rewriteReferences(v, idToLabel);
+    }
+    return out;
+  }
+  if (typeof value === "string") {
+    const exactLabel = idToLabel[value.toLowerCase()];
+    if (GUID_REGEX.test(value) && exactLabel) {
+      return rawHcl(`msgraph_resource.${exactLabel}.id`);
+    }
+    let changed = false;
+    const replaced = value.replace(GUID_GLOBAL_REGEX, (guid) => {
+      const label = idToLabel[guid.toLowerCase()];
+      if (!label) return guid;
+      changed = true;
+      return `\${msgraph_resource.${label}.id}`;
+    });
+    return changed ? replaced : value;
+  }
+  return value;
+}
+
+// Shared two-pass renderer for both the single-request and $batch paths.
+// A unit is { item, url, apiVersion, treatAsCreate, seed }:
+//   - treatAsCreate true  => user-authored create body: keep read-only keys, no warning
+//   - treatAsCreate false => server/GET-derived body: strip read-only keys, add warning
+// Pass 1 assigns unique labels and maps each item's id -> label (across all
+// units) so Pass 2 can rewrite cross-resource references.
+function renderResourceUnits(units) {
+  const used = new Set();
+  const idToLabel = {};
+  const prepared = [];
+
+  for (const unit of units) {
+    const { item, url, apiVersion, treatAsCreate, seed } = unit;
+    if (!item || typeof item !== "object") continue;
+    const cleaned = stripReadOnlyFields(item, 0, { stripReadOnlyKeys: !treatAsCreate });
+    if (!cleaned || Object.keys(cleaned).length === 0) continue;
+    const baseLabel = buildResourceLabel(url, item, seed);
+    const label = uniqueLabel(baseLabel, used);
+    if (typeof item.id === "string" && GUID_REGEX.test(item.id)) {
+      idToLabel[item.id.toLowerCase()] = label;
+    }
+    prepared.push({ label, url, apiVersion, cleaned, treatAsCreate });
+  }
+
+  const blocks = [];
+  for (const p of prepared) {
+    const body = rewriteReferences(p.cleaned, idToLabel);
+    const block = renderTerraformBlock(p.label, p.url, p.apiVersion, body);
+    blocks.push(p.treatAsCreate ? block : prependGetWarning(block));
+  }
+  return blocks;
+}
+
+function generateLocalTerraformBatchSnippet(requestBody, responseBody, experimentalCreateFromGet = false) {
   const responseEnvelope = tryParseJson(responseBody);
   if (!responseEnvelope || !Array.isArray(responseEnvelope.responses)) return null;
 
@@ -334,37 +433,63 @@ function generateLocalTerraformBatchSnippet(requestBody, responseBody) {
     }
   }
 
-  const used = new Set();
-  const blocks = [];
+  const units = [];
 
   for (const resp of responseEnvelope.responses) {
     if (!resp || typeof resp !== "object") continue;
     if (typeof resp.status === "number" && (resp.status < 200 || resp.status >= 300)) continue;
 
-    const body = resp.body;
-    if (!body || typeof body !== "object") continue;
+    const req = requestsById[String(resp.id)];
+    const reqMethod = req && typeof req.method === "string" ? req.method.toUpperCase() : null;
+    const isCreate = reqMethod === "POST" || reqMethod === "PUT" || reqMethod === "PATCH";
 
-    let target = parseODataContext(body["@odata.context"]);
-    if (!target) {
-      const req = requestsById[String(resp.id)];
-      if (req && typeof req.url === "string") {
+    // GET-derived sub-resources are adoption — keep them gated behind the flag,
+    // consistent with single-request GET handling. Real creates are always emitted.
+    if (!isCreate && !experimentalCreateFromGet) continue;
+
+    let source = null;
+    let target = null;
+
+    if (isCreate) {
+      // Prefer the request payload — the authoritative create body.
+      const reqBody = req && req.body != null ? req.body : null;
+      const parsedReqBody = typeof reqBody === "string" ? tryParseJson(reqBody) : reqBody;
+      source =
+        parsedReqBody && typeof parsedReqBody === "object"
+          ? parsedReqBody
+          : resp.body && typeof resp.body === "object"
+          ? resp.body
+          : null;
+      if (typeof req.url === "string") target = normalizeTerraformUrl(req.url);
+      if ((!target || !target.url) && resp.body && typeof resp.body === "object") {
+        target = parseODataContext(resp.body["@odata.context"]);
+      }
+    } else {
+      const body = resp.body;
+      if (!body || typeof body !== "object") continue;
+      source = body;
+      target = parseODataContext(body["@odata.context"]);
+      if ((!target || !target.url) && req && typeof req.url === "string") {
         target = normalizeTerraformUrl(req.url);
       }
     }
+
+    if (!source || typeof source !== "object") continue;
     if (!target || !target.url) continue;
 
-    const items = Array.isArray(body.value) ? body.value : [body];
+    const items = Array.isArray(source.value) ? source.value : [source];
     items.forEach((item, idx) => {
-      if (!item || typeof item !== "object") return;
-      const cleaned = stripReadOnlyFields(item);
-      if (!cleaned || Object.keys(cleaned).length === 0) return;
-      const baseLabel = buildResourceLabel(target.url, item, `${resp.id}#${idx}`);
-      const label = uniqueLabel(baseLabel, used);
-      const block = renderTerraformBlock(label, target.url, target.apiVersion, cleaned);
-      blocks.push(prependGetWarning(block));
+      units.push({
+        item,
+        url: target.url,
+        apiVersion: target.apiVersion,
+        treatAsCreate: isCreate,
+        seed: `${resp.id}#${idx}`,
+      });
     });
   }
 
+  const blocks = renderResourceUnits(units);
   if (blocks.length === 0) return null;
   return blocks.join("\n\n");
 }
@@ -374,36 +499,32 @@ function generateLocalTerraformSnippet(method, url, requestBody, responseBody, e
   if (methodUpper === "DELETE" || methodUpper === "OPTIONS") return null;
 
   // $batch: adopt resources from the sub-response bodies, not the batch envelope.
+  // The batch generator decides per sub-request whether each item is a real
+  // create (always emitted) or GET-derived adoption (gated by the flag).
   if (typeof url === "string" && url.includes("/$batch")) {
-    if (!experimentalCreateFromGet) return null; // gated like single-resource GET adoption
-    return generateLocalTerraformBatchSnippet(requestBody, responseBody);
+    return generateLocalTerraformBatchSnippet(requestBody, responseBody, experimentalCreateFromGet);
   }
 
   if (methodUpper === "GET" && !experimentalCreateFromGet) return null;
 
-  const source =
-    methodUpper === "GET" ? responseBody || requestBody : requestBody || responseBody;
+  const isCreate = methodUpper !== "GET";
+  const source = isCreate ? requestBody || responseBody : responseBody || requestBody;
   const parsed = tryParseJson(source);
   if (parsed === null || typeof parsed !== "object") return null;
 
   const { url: normalizedUrl, apiVersion } = normalizeTerraformUrl(url);
   if (!normalizedUrl) return null;
 
-  const used = new Set();
-  const items =
-    parsed && Array.isArray(parsed.value) ? parsed.value : [parsed];
+  const items = Array.isArray(parsed.value) ? parsed.value : [parsed];
+  const units = items.map((item, idx) => ({
+    item,
+    url: normalizedUrl,
+    apiVersion,
+    treatAsCreate: isCreate,
+    seed: `${url}#${idx}`,
+  }));
 
-  const blocks = [];
-  items.forEach((item, idx) => {
-    if (!item || typeof item !== "object") return;
-    const cleaned = stripReadOnlyFields(item);
-    if (!cleaned || Object.keys(cleaned).length === 0) return;
-    const baseLabel = buildResourceLabel(normalizedUrl, item, `${url}#${idx}`);
-    const label = uniqueLabel(baseLabel, used);
-    const block = renderTerraformBlock(label, normalizedUrl, apiVersion, cleaned);
-    blocks.push(methodUpper === "GET" ? prependGetWarning(block) : block);
-  });
-
+  const blocks = renderResourceUnits(units);
   if (blocks.length === 0) return null;
   return blocks.join("\n\n");
 }
@@ -812,4 +933,6 @@ export {
   tryParseJson,
   parseODataContext,
   generateLocalTerraformBatchSnippet,
+  rewriteReferences,
+  rawHcl,
 };

--- a/src/common/client.js
+++ b/src/common/client.js
@@ -273,6 +273,15 @@ function renderTerraformBlock(label, url, apiVersion, body) {
   return lines.join("\n");
 }
 
+function prependGetWarning(block) {
+  return [
+    "# WARNING: Generated from a GET response - review before apply.",
+    "# Read-only and server-generated fields were stripped heuristically;",
+    "# verify required attributes, defaults, and @odata discriminators.",
+    block,
+  ].join("\n");
+}
+
 function uniqueLabel(base, used) {
   if (!used.has(base)) {
     used.add(base);
@@ -296,9 +305,10 @@ function tryParseJson(text) {
   }
 }
 
-function generateTerraformSnippet(method, url, requestBody, responseBody) {
+function generateTerraformSnippet(method, url, requestBody, responseBody, experimentalCreateFromGet = false) {
   const methodUpper = (method || "GET").toUpperCase();
   if (methodUpper === "DELETE" || methodUpper === "OPTIONS") return null;
+  if (methodUpper === "GET" && !experimentalCreateFromGet) return null;
 
   const source =
     methodUpper === "GET" ? responseBody || requestBody : requestBody || responseBody;
@@ -319,7 +329,8 @@ function generateTerraformSnippet(method, url, requestBody, responseBody) {
     if (!cleaned || Object.keys(cleaned).length === 0) return;
     const baseLabel = buildResourceLabel(normalizedUrl, item, `${url}#${idx}`);
     const label = uniqueLabel(baseLabel, used);
-    blocks.push(renderTerraformBlock(label, normalizedUrl, apiVersion, cleaned));
+    const block = renderTerraformBlock(label, normalizedUrl, apiVersion, cleaned);
+    blocks.push(methodUpper === "GET" ? prependGetWarning(block) : block);
   });
 
   if (blocks.length === 0) return null;
@@ -338,7 +349,13 @@ async function getSnippetFromDevX(snippetLanguage, method, url, body, options = 
 
   // Terraform (msgraph): always generate locally, DevX has no Terraform support
   if (snippetLanguage === "terraform") {
-    return generateTerraformSnippet(method, url, body ?? "", options.responseBody ?? "");
+    return generateTerraformSnippet(
+      method,
+      url,
+      body ?? "",
+      options.responseBody ?? "",
+      options.experimentalCreateFromGet === true,
+    );
   }
 
   // PowerShell (Invoke-MgGraphRequest): always use local generation, never call DevX

--- a/src/common/client.js
+++ b/src/common/client.js
@@ -724,3 +724,20 @@ const getCodeView = async function (
   return codeView;
 };
 export { getPowershellCmd, getRequestBody, getResponseContent, getCodeView, getBatchCodeSnippets, generateLocalPowerShellSnippet, generateTerraformSnippet };
+
+// Terraform helpers exported for unit testing.
+export {
+  hashUrl,
+  sanitizeLabel,
+  shouldStripOdataKey,
+  stripReadOnlyFields,
+  formatHclString,
+  formatHclValue,
+  normalizeTerraformUrl,
+  leafCollectionName,
+  buildResourceLabel,
+  renderTerraformBlock,
+  prependGetWarning,
+  uniqueLabel,
+  tryParseJson,
+};

--- a/src/common/client.js
+++ b/src/common/client.js
@@ -109,8 +109,7 @@ const TF_READONLY_KEYS = new Set([
   "renewedDateTime",
   "modifiedDateTime",
 ]);
-// @odata annotations that are server-generated and should be stripped from a recreate template.
-// Anything not listed here (notably @odata.type discriminators and *@odata.bind references) is kept.
+
 const TF_STRIP_ODATA_SUFFIXES = [
   "@odata.context",
   "@odata.nextLink",
@@ -305,12 +304,6 @@ function tryParseJson(text) {
   }
 }
 
-// Parse a Graph @odata.context into the resource path and api version, mirroring
-// normalizeTerraformUrl's return shape. e.g.
-//   https://graph.microsoft.com/beta/$metadata#identity/identityProviders
-//     -> { url: "identity/identityProviders", apiVersion: "beta" }
-//   https://graph.microsoft.com/v1.0/$metadata#groups/$entity
-//     -> { url: "groups", apiVersion: null }
 function parseODataContext(context) {
   if (typeof context !== "string") return null;
   const marker = context.indexOf("$metadata#");
@@ -329,10 +322,7 @@ function parseODataContext(context) {
   return { url: fragment, apiVersion };
 }
 
-// Generate terraform "adopt" templates from a Graph $batch response envelope.
-// Each successful sub-response body yields one msgraph_resource block per resource,
-// with the path/version taken from @odata.context (falling back to the paired request).
-function generateTerraformBatchSnippet(requestBody, responseBody) {
+function generateLocalTerraformBatchSnippet(requestBody, responseBody) {
   const responseEnvelope = tryParseJson(responseBody);
   if (!responseEnvelope || !Array.isArray(responseEnvelope.responses)) return null;
 
@@ -379,14 +369,14 @@ function generateTerraformBatchSnippet(requestBody, responseBody) {
   return blocks.join("\n\n");
 }
 
-function generateTerraformSnippet(method, url, requestBody, responseBody, experimentalCreateFromGet = false) {
+function generateLocalTerraformSnippet(method, url, requestBody, responseBody, experimentalCreateFromGet = false) {
   const methodUpper = (method || "GET").toUpperCase();
   if (methodUpper === "DELETE" || methodUpper === "OPTIONS") return null;
 
   // $batch: adopt resources from the sub-response bodies, not the batch envelope.
   if (typeof url === "string" && url.includes("/$batch")) {
     if (!experimentalCreateFromGet) return null; // gated like single-resource GET adoption
-    return generateTerraformBatchSnippet(requestBody, responseBody);
+    return generateLocalTerraformBatchSnippet(requestBody, responseBody);
   }
 
   if (methodUpper === "GET" && !experimentalCreateFromGet) return null;
@@ -428,9 +418,9 @@ async function getSnippetFromDevX(snippetLanguage, method, url, body, options = 
     return fullUrl;
   }
 
-  // Terraform (msgraph): always generate locally, DevX has no Terraform support
+
   if (snippetLanguage === "terraform") {
-    return generateTerraformSnippet(
+    return generateLocalTerraformSnippet(
       method,
       url,
       body ?? "",
@@ -804,9 +794,8 @@ const getCodeView = async function (
   console.log("CodeView", codeView);
   return codeView;
 };
-export { getPowershellCmd, getRequestBody, getResponseContent, getCodeView, getBatchCodeSnippets, generateLocalPowerShellSnippet, generateTerraformSnippet };
+export { getPowershellCmd, getRequestBody, getResponseContent, getCodeView, getBatchCodeSnippets, generateLocalPowerShellSnippet, generateLocalTerraformSnippet };
 
-// Terraform helpers exported for unit testing.
 export {
   hashUrl,
   sanitizeLabel,
@@ -822,5 +811,5 @@ export {
   uniqueLabel,
   tryParseJson,
   parseODataContext,
-  generateTerraformBatchSnippet,
+  generateLocalTerraformBatchSnippet,
 };

--- a/src/common/client.js
+++ b/src/common/client.js
@@ -101,7 +101,7 @@ function generateLocalPowerShellSnippet(method, url, body, options = {}) {
 }
 
 const GUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-const HCL_IDENT_REGEX = /^[A-Za-z_][A-Za-z0-9_-]*$/;
+const HCL_IDENT_REGEX = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const TF_READONLY_KEYS = new Set([
   "id",
   "createdDateTime",

--- a/src/common/client.js
+++ b/src/common/client.js
@@ -305,9 +305,90 @@ function tryParseJson(text) {
   }
 }
 
+// Parse a Graph @odata.context into the resource path and api version, mirroring
+// normalizeTerraformUrl's return shape. e.g.
+//   https://graph.microsoft.com/beta/$metadata#identity/identityProviders
+//     -> { url: "identity/identityProviders", apiVersion: "beta" }
+//   https://graph.microsoft.com/v1.0/$metadata#groups/$entity
+//     -> { url: "groups", apiVersion: null }
+function parseODataContext(context) {
+  if (typeof context !== "string") return null;
+  const marker = context.indexOf("$metadata#");
+  if (marker === -1) return null;
+
+  const before = context.slice(0, marker);
+  const apiVersion = /\/beta\//i.test(before) ? "beta" : null;
+
+  const fragment = context
+    .slice(marker + "$metadata#".length)
+    .replace(/\([^)]*\)/g, "") // strip projection / key-selector parens
+    .replace(/\/\$entity$/i, "") // strip trailing single-entity marker
+    .replace(/^\/+|\/+$/g, "");
+
+  if (!fragment) return null;
+  return { url: fragment, apiVersion };
+}
+
+// Generate terraform "adopt" templates from a Graph $batch response envelope.
+// Each successful sub-response body yields one msgraph_resource block per resource,
+// with the path/version taken from @odata.context (falling back to the paired request).
+function generateTerraformBatchSnippet(requestBody, responseBody) {
+  const responseEnvelope = tryParseJson(responseBody);
+  if (!responseEnvelope || !Array.isArray(responseEnvelope.responses)) return null;
+
+  const requestEnvelope = tryParseJson(requestBody);
+  const requestsById = {};
+  if (requestEnvelope && Array.isArray(requestEnvelope.requests)) {
+    for (const req of requestEnvelope.requests) {
+      if (req && req.id != null) requestsById[String(req.id)] = req;
+    }
+  }
+
+  const used = new Set();
+  const blocks = [];
+
+  for (const resp of responseEnvelope.responses) {
+    if (!resp || typeof resp !== "object") continue;
+    if (typeof resp.status === "number" && (resp.status < 200 || resp.status >= 300)) continue;
+
+    const body = resp.body;
+    if (!body || typeof body !== "object") continue;
+
+    let target = parseODataContext(body["@odata.context"]);
+    if (!target) {
+      const req = requestsById[String(resp.id)];
+      if (req && typeof req.url === "string") {
+        target = normalizeTerraformUrl(req.url);
+      }
+    }
+    if (!target || !target.url) continue;
+
+    const items = Array.isArray(body.value) ? body.value : [body];
+    items.forEach((item, idx) => {
+      if (!item || typeof item !== "object") return;
+      const cleaned = stripReadOnlyFields(item);
+      if (!cleaned || Object.keys(cleaned).length === 0) return;
+      const baseLabel = buildResourceLabel(target.url, item, `${resp.id}#${idx}`);
+      const label = uniqueLabel(baseLabel, used);
+      const block = renderTerraformBlock(label, target.url, target.apiVersion, cleaned);
+      blocks.push(prependGetWarning(block));
+    });
+  }
+
+  if (blocks.length === 0) return null;
+  return blocks.join("\n\n");
+}
+
 function generateTerraformSnippet(method, url, requestBody, responseBody, experimentalCreateFromGet = false) {
   const methodUpper = (method || "GET").toUpperCase();
   if (methodUpper === "DELETE" || methodUpper === "OPTIONS") return null;
+
+  // $batch: adopt resources from the sub-response bodies, not the batch envelope.
+  if (typeof url === "string" && url.includes("/$batch")) {
+    if (!experimentalCreateFromGet) return null; // gated like single-resource GET adoption
+    return generateTerraformBatchSnippet(requestBody, responseBody);
+  }
+
   if (methodUpper === "GET" && !experimentalCreateFromGet) return null;
 
   const source =
@@ -740,4 +821,6 @@ export {
   prependGetWarning,
   uniqueLabel,
   tryParseJson,
+  parseODataContext,
+  generateTerraformBatchSnippet,
 };

--- a/src/common/client.test.js
+++ b/src/common/client.test.js
@@ -13,6 +13,8 @@ import {
   hashUrl,
   leafCollectionName,
   tryParseJson,
+  parseODataContext,
+  generateTerraformBatchSnippet,
 } from "./client.js";
 
 const GUID = "12345678-1234-1234-1234-123456789012";
@@ -567,5 +569,289 @@ describe("generateTerraformSnippet", () => {
 
     const v1 = generateTerraformSnippet("POST", URL, '{"displayName":"X"}', "");
     expect(v1).not.toContain("api_version");
+  });
+});
+
+describe("parseODataContext", () => {
+  it("parses a collection context into path + beta api version", () => {
+    expect(
+      parseODataContext(
+        "https://graph.microsoft.com/beta/$metadata#identity/identityProviders"
+      )
+    ).toEqual({ url: "identity/identityProviders", apiVersion: "beta" });
+  });
+
+  it("reports null api version for a v1.0 context", () => {
+    expect(
+      parseODataContext("https://graph.microsoft.com/v1.0/$metadata#groups")
+    ).toEqual({ url: "groups", apiVersion: null });
+  });
+
+  it("strips a trailing /$entity single-entity marker", () => {
+    expect(
+      parseODataContext("https://graph.microsoft.com/v1.0/$metadata#groups/$entity")
+    ).toEqual({ url: "groups", apiVersion: null });
+  });
+
+  it("strips projection and key-selector parens", () => {
+    expect(
+      parseODataContext(
+        "https://graph.microsoft.com/v1.0/$metadata#users(id,displayName)"
+      )
+    ).toEqual({ url: "users", apiVersion: null });
+    expect(
+      parseODataContext("https://graph.microsoft.com/v1.0/$metadata#groups('abc')")
+    ).toEqual({ url: "groups", apiVersion: null });
+  });
+
+  it("returns null when the $metadata marker is missing", () => {
+    expect(parseODataContext("https://graph.microsoft.com/v1.0/groups")).toBeNull();
+  });
+
+  it("returns null for non-string input", () => {
+    expect(parseODataContext(null)).toBeNull();
+    expect(parseODataContext(undefined)).toBeNull();
+    expect(parseODataContext(42)).toBeNull();
+  });
+
+  it("returns null when the fragment is empty", () => {
+    expect(parseODataContext("https://graph.microsoft.com/v1.0/$metadata#")).toBeNull();
+  });
+});
+
+// The real $batch response payload provided for this feature.
+const IDENTITY_PROVIDERS_BATCH = JSON.stringify({
+  responses: [
+    {
+      id: "38e548c6-045f-4a4a-9b18-b8d8644cf94e",
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+      body: {
+        "@odata.context":
+          "https://graph.microsoft.com/beta/$metadata#identity/identityProviders",
+        value: [
+          {
+            "@odata.type": "#microsoft.graph.socialIdentityProvider",
+            id: "5a415368-09cf-42df-a00c-ec23d9f4ebce",
+            displayName: "Facebook",
+            supportedTenantTypes: "externalId",
+            identityProviderType: "Facebook",
+            clientId: "1515151515151515",
+            clientSecret: "******",
+          },
+          {
+            "@odata.type": "#microsoft.graph.oidcIdentityProvider",
+            id: "6d5887a6-131d-44a6-95ed-ff8c2cd57f42",
+            displayName: "WorkforceEntraId",
+            supportedTenantTypes: "externalId",
+            clientId: "a9a9a9a9-a9a9-a9a9-a9a9-a9a9a9a9a9a9",
+            issuer:
+              "https://login.microsoftonline.com/c5c5c5c5-c5c5-c5c5-c5c5-c5c5c5c5c5c5/v2.0",
+            responseType: "code",
+            scope: "openid profile",
+            clientAuthentication: {
+              "@odata.type": "#microsoft.graph.oidcClientSecretAuthentication",
+              clientSecret: "******",
+            },
+          },
+        ],
+      },
+    },
+  ],
+});
+
+describe("generateTerraformBatchSnippet", () => {
+  it("generates one adopt block per resource in the provided identityProviders payload", () => {
+    const out = generateTerraformBatchSnippet("", IDENTITY_PROVIDERS_BATCH);
+    const blocks = out.split("\n\n");
+    expect(blocks).toHaveLength(2);
+  });
+
+  it("derives url and beta api_version from @odata.context", () => {
+    const out = generateTerraformBatchSnippet("", IDENTITY_PROVIDERS_BATCH);
+    expect(out).toContain('url = "identity/identityProviders"');
+    expect(out).toContain('api_version = "beta"');
+  });
+
+  it("preserves @odata.type discriminators and strips read-only ids", () => {
+    const out = generateTerraformBatchSnippet("", IDENTITY_PROVIDERS_BATCH);
+    // (HCL aligns the `=`, so match the quoted key + value without assuming spacing)
+    expect(out).toContain('"@odata.type"');
+    expect(out).toContain('"#microsoft.graph.oidcIdentityProvider"');
+    expect(out).toContain('"#microsoft.graph.socialIdentityProvider"');
+    // nested discriminator preserved
+    expect(out).toContain('"#microsoft.graph.oidcClientSecretAuthentication"');
+    expect(out).not.toContain("5a415368-09cf-42df-a00c-ec23d9f4ebce"); // top-level id stripped
+  });
+
+  it("keeps non-read-only fields such as clientSecret", () => {
+    const out = generateTerraformBatchSnippet("", IDENTITY_PROVIDERS_BATCH);
+    expect(out).toMatch(/clientSecret\s+=\s+"\*{6}"/);
+  });
+
+  it("prepends a GET/adopt warning to every block", () => {
+    const out = generateTerraformBatchSnippet("", IDENTITY_PROVIDERS_BATCH);
+    const warnings = out.match(/# WARNING: Generated from a GET response/g);
+    expect(warnings).toHaveLength(2);
+  });
+
+  it("derives labels from displayName", () => {
+    const out = generateTerraformBatchSnippet("", IDENTITY_PROVIDERS_BATCH);
+    expect(out).toContain('"identity_providers_facebook"');
+    expect(out).toContain('"identity_providers_workforce_entra_id"');
+  });
+
+  it("returns null for an invalid or non-batch response envelope", () => {
+    expect(generateTerraformBatchSnippet("", "not json")).toBeNull();
+    expect(generateTerraformBatchSnippet("", "{}")).toBeNull();
+    expect(generateTerraformBatchSnippet("", '{"value":[]}')).toBeNull();
+  });
+
+  it("skips non-2xx sub-responses", () => {
+    const envelope = JSON.stringify({
+      responses: [
+        {
+          id: "1",
+          status: 404,
+          body: {
+            "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#groups/$entity",
+            displayName: "Missing",
+          },
+        },
+        {
+          id: "2",
+          status: 200,
+          body: {
+            "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#groups/$entity",
+            displayName: "Present",
+          },
+        },
+      ],
+    });
+    const out = generateTerraformBatchSnippet("", envelope);
+    expect(out).toContain('"group_present"');
+    expect(out).not.toContain("Missing");
+  });
+
+  it("handles a single-entity body (no value array)", () => {
+    const envelope = JSON.stringify({
+      responses: [
+        {
+          id: "1",
+          status: 200,
+          body: {
+            "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#groups/$entity",
+            id: GUID,
+            displayName: "Solo",
+          },
+        },
+      ],
+    });
+    const out = generateTerraformBatchSnippet("", envelope);
+    expect(out.split("\n\n")).toHaveLength(1);
+    expect(out).toContain('"group_solo"');
+    expect(out).toContain('url = "groups"');
+    expect(out).not.toContain(GUID);
+  });
+
+  it("falls back to the paired request url when @odata.context is absent", () => {
+    const requestBody = JSON.stringify({
+      requests: [{ id: "42", method: "GET", url: "/groups" }],
+    });
+    const responseBody = JSON.stringify({
+      responses: [{ id: "42", status: 200, body: { displayName: "FromReq" } }],
+    });
+    const out = generateTerraformBatchSnippet(requestBody, responseBody);
+    expect(out).toContain('url = "groups"');
+    expect(out).toContain('"group_from_req"'); // sanitizeLabel("FromReq") -> from_req
+  });
+
+  it("skips responses with no resolvable url and no body fields", () => {
+    const responseBody = JSON.stringify({
+      responses: [
+        { id: "1", status: 200, body: { displayName: "NoContext" } },
+      ],
+    });
+    // no @odata.context and no matching request => skipped
+    expect(generateTerraformBatchSnippet("", responseBody)).toBeNull();
+  });
+
+  it("skips an item that is empty after stripping read-only fields", () => {
+    const responseBody = JSON.stringify({
+      responses: [
+        {
+          id: "1",
+          status: 200,
+          body: {
+            "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#groups/$entity",
+            id: GUID,
+          },
+        },
+      ],
+    });
+    expect(generateTerraformBatchSnippet("", responseBody)).toBeNull();
+  });
+
+  it("de-duplicates labels across responses", () => {
+    const responseBody = JSON.stringify({
+      responses: [
+        {
+          id: "1",
+          status: 200,
+          body: {
+            "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#groups/$entity",
+            displayName: "Dup",
+          },
+        },
+        {
+          id: "2",
+          status: 200,
+          body: {
+            "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#groups/$entity",
+            displayName: "Dup",
+          },
+        },
+      ],
+    });
+    const out = generateTerraformBatchSnippet("", responseBody);
+    expect(out).toContain('"group_dup"');
+    expect(out).toContain('"group_dup_2"');
+  });
+});
+
+describe("generateTerraformSnippet ($batch integration)", () => {
+  const BATCH_URL = "https://graph.microsoft.com/beta/$batch";
+
+  it("produces adopt blocks for a $batch when the experimental flag is set", () => {
+    const out = generateTerraformSnippet(
+      "POST",
+      BATCH_URL,
+      "",
+      IDENTITY_PROVIDERS_BATCH,
+      true
+    );
+    expect(out.split("\n\n")).toHaveLength(2);
+    expect(out).toContain('url = "identity/identityProviders"');
+  });
+
+  it("returns null for a $batch without the experimental flag", () => {
+    expect(
+      generateTerraformSnippet("POST", BATCH_URL, "", IDENTITY_PROVIDERS_BATCH)
+    ).toBeNull();
+  });
+
+  it("does not render the request envelope as a resource", () => {
+    const requestBody = JSON.stringify({
+      requests: [{ id: "1", method: "GET", url: "/identity/identityProviders" }],
+    });
+    const out = generateTerraformSnippet(
+      "POST",
+      BATCH_URL,
+      requestBody,
+      IDENTITY_PROVIDERS_BATCH,
+      true
+    );
+    expect(out).not.toContain('"requests"');
+    expect(out).not.toContain("$batch");
   });
 });

--- a/src/common/client.test.js
+++ b/src/common/client.test.js
@@ -15,6 +15,8 @@ import {
   tryParseJson,
   parseODataContext,
   generateLocalTerraformBatchSnippet,
+  rewriteReferences,
+  rawHcl,
 } from "./client.js";
 
 const GUID = "12345678-1234-1234-1234-123456789012";
@@ -662,19 +664,19 @@ const IDENTITY_PROVIDERS_BATCH = JSON.stringify({
 
 describe("generateLocalTerraformBatchSnippet", () => {
   it("generates one adopt block per resource in the provided identityProviders payload", () => {
-    const out = generateLocalTerraformBatchSnippet("", IDENTITY_PROVIDERS_BATCH);
+    const out = generateLocalTerraformBatchSnippet("", IDENTITY_PROVIDERS_BATCH, true);
     const blocks = out.split("\n\n");
     expect(blocks).toHaveLength(2);
   });
 
   it("derives url and beta api_version from @odata.context", () => {
-    const out = generateLocalTerraformBatchSnippet("", IDENTITY_PROVIDERS_BATCH);
+    const out = generateLocalTerraformBatchSnippet("", IDENTITY_PROVIDERS_BATCH, true);
     expect(out).toContain('url = "identity/identityProviders"');
     expect(out).toContain('api_version = "beta"');
   });
 
   it("preserves @odata.type discriminators and strips read-only ids", () => {
-    const out = generateLocalTerraformBatchSnippet("", IDENTITY_PROVIDERS_BATCH);
+    const out = generateLocalTerraformBatchSnippet("", IDENTITY_PROVIDERS_BATCH, true);
     // (HCL aligns the `=`, so match the quoted key + value without assuming spacing)
     expect(out).toContain('"@odata.type"');
     expect(out).toContain('"#microsoft.graph.oidcIdentityProvider"');
@@ -685,18 +687,18 @@ describe("generateLocalTerraformBatchSnippet", () => {
   });
 
   it("keeps non-read-only fields such as clientSecret", () => {
-    const out = generateLocalTerraformBatchSnippet("", IDENTITY_PROVIDERS_BATCH);
+    const out = generateLocalTerraformBatchSnippet("", IDENTITY_PROVIDERS_BATCH, true);
     expect(out).toMatch(/clientSecret\s+=\s+"\*{6}"/);
   });
 
   it("prepends a GET/adopt warning to every block", () => {
-    const out = generateLocalTerraformBatchSnippet("", IDENTITY_PROVIDERS_BATCH);
+    const out = generateLocalTerraformBatchSnippet("", IDENTITY_PROVIDERS_BATCH, true);
     const warnings = out.match(/# WARNING: Generated from a GET response/g);
     expect(warnings).toHaveLength(2);
   });
 
   it("derives labels from displayName", () => {
-    const out = generateLocalTerraformBatchSnippet("", IDENTITY_PROVIDERS_BATCH);
+    const out = generateLocalTerraformBatchSnippet("", IDENTITY_PROVIDERS_BATCH, true);
     expect(out).toContain('"identity_providers_facebook"');
     expect(out).toContain('"identity_providers_workforce_entra_id"');
   });
@@ -728,7 +730,7 @@ describe("generateLocalTerraformBatchSnippet", () => {
         },
       ],
     });
-    const out = generateLocalTerraformBatchSnippet("", envelope);
+    const out = generateLocalTerraformBatchSnippet("", envelope, true);
     expect(out).toContain('"group_present"');
     expect(out).not.toContain("Missing");
   });
@@ -747,7 +749,7 @@ describe("generateLocalTerraformBatchSnippet", () => {
         },
       ],
     });
-    const out = generateLocalTerraformBatchSnippet("", envelope);
+    const out = generateLocalTerraformBatchSnippet("", envelope, true);
     expect(out.split("\n\n")).toHaveLength(1);
     expect(out).toContain('"group_solo"');
     expect(out).toContain('url = "groups"');
@@ -761,7 +763,7 @@ describe("generateLocalTerraformBatchSnippet", () => {
     const responseBody = JSON.stringify({
       responses: [{ id: "42", status: 200, body: { displayName: "FromReq" } }],
     });
-    const out = generateLocalTerraformBatchSnippet(requestBody, responseBody);
+    const out = generateLocalTerraformBatchSnippet(requestBody, responseBody, true);
     expect(out).toContain('url = "groups"');
     expect(out).toContain('"group_from_req"'); // sanitizeLabel("FromReq") -> from_req
   });
@@ -773,7 +775,7 @@ describe("generateLocalTerraformBatchSnippet", () => {
       ],
     });
     // no @odata.context and no matching request => skipped
-    expect(generateLocalTerraformBatchSnippet("", responseBody)).toBeNull();
+    expect(generateLocalTerraformBatchSnippet("", responseBody, true)).toBeNull();
   });
 
   it("skips an item that is empty after stripping read-only fields", () => {
@@ -789,7 +791,7 @@ describe("generateLocalTerraformBatchSnippet", () => {
         },
       ],
     });
-    expect(generateLocalTerraformBatchSnippet("", responseBody)).toBeNull();
+    expect(generateLocalTerraformBatchSnippet("", responseBody, true)).toBeNull();
   });
 
   it("de-duplicates labels across responses", () => {
@@ -813,7 +815,7 @@ describe("generateLocalTerraformBatchSnippet", () => {
         },
       ],
     });
-    const out = generateLocalTerraformBatchSnippet("", responseBody);
+    const out = generateLocalTerraformBatchSnippet("", responseBody, true);
     expect(out).toContain('"group_dup"');
     expect(out).toContain('"group_dup_2"');
   });
@@ -853,5 +855,207 @@ describe("generateLocalTerraformSnippet ($batch integration)", () => {
     );
     expect(out).not.toContain('"requests"');
     expect(out).not.toContain("$batch");
+  });
+});
+
+describe("stripReadOnlyFields (source-aware)", () => {
+  it("strips expanded server-computed top-level fields by default", () => {
+    const out = stripReadOnlyFields({
+      appId: "abc",
+      servicePrincipalType: "Application",
+      publisherName: "Contoso",
+      displayName: "Keep me",
+    });
+    expect(out).toEqual({ displayName: "Keep me" });
+  });
+
+  it("keeps server-computed keys when stripReadOnlyKeys is false but always strips id", () => {
+    const body = { id: GUID, appId: "abc", displayName: "App" };
+    expect(stripReadOnlyFields(body, 0, { stripReadOnlyKeys: false })).toEqual({
+      appId: "abc",
+      displayName: "App",
+    });
+  });
+
+  it("still strips @odata annotations even when stripReadOnlyKeys is false", () => {
+    const out = stripReadOnlyFields(
+      { "@odata.context": "x", "@odata.type": "#t", displayName: "App" },
+      0,
+      { stripReadOnlyKeys: false }
+    );
+    expect(out).toEqual({ "@odata.type": "#t", displayName: "App" });
+  });
+});
+
+describe("rawHcl / formatHclValue raw expressions", () => {
+  it("emits a rawHcl marker verbatim (unquoted)", () => {
+    expect(formatHclValue(rawHcl("msgraph_resource.group_x.id"), "")).toBe(
+      "msgraph_resource.group_x.id"
+    );
+  });
+
+  it("renders a raw reference inside an object without quotes", () => {
+    const out = formatHclValue({ owner: rawHcl("msgraph_resource.user_a.id") }, "");
+    expect(out).toContain("owner = msgraph_resource.user_a.id");
+    expect(out).not.toContain('"msgraph_resource');
+  });
+});
+
+describe("rewriteReferences", () => {
+  const idToLabel = { [GUID.toLowerCase()]: "group_x" };
+
+  it("rewrites a bare GUID string into a raw reference expression", () => {
+    expect(rewriteReferences(GUID, idToLabel)).toEqual(
+      rawHcl("msgraph_resource.group_x.id")
+    );
+  });
+
+  it("rewrites a GUID embedded in an @odata.bind URL into an interpolation", () => {
+    const bind = `https://graph.microsoft.com/v1.0/directoryObjects/${GUID}`;
+    expect(rewriteReferences({ "owners@odata.bind": [bind] }, idToLabel)).toEqual({
+      "owners@odata.bind": [
+        "https://graph.microsoft.com/v1.0/directoryObjects/${msgraph_resource.group_x.id}",
+      ],
+    });
+  });
+
+  it("leaves GUIDs that are not emitted in the snippet untouched", () => {
+    const other = "99999999-9999-9999-9999-999999999999";
+    expect(rewriteReferences(other, idToLabel)).toBe(other);
+    expect(rewriteReferences({ ref: other }, idToLabel)).toEqual({ ref: other });
+  });
+
+  it("matches GUIDs case-insensitively", () => {
+    const upper = GUID.toUpperCase();
+    expect(rewriteReferences(upper, idToLabel)).toEqual(
+      rawHcl("msgraph_resource.group_x.id")
+    );
+  });
+});
+
+describe("generateLocalTerraformSnippet (cross-resource references)", () => {
+  it("rewrites an @odata.bind to a sibling resource emitted in the same snippet", () => {
+    const aId = GUID;
+    const responseBody = JSON.stringify({
+      value: [
+        { id: aId, displayName: "Alice" },
+        {
+          id: "22222222-2222-2222-2222-222222222222",
+          displayName: "Bob",
+          "manager@odata.bind": `https://graph.microsoft.com/v1.0/directoryObjects/${aId}`,
+        },
+      ],
+    });
+    const out = generateLocalTerraformSnippet(
+      "GET",
+      "https://graph.microsoft.com/v1.0/users",
+      "",
+      responseBody,
+      true
+    );
+    expect(out).toContain("${msgraph_resource.user_alice.id}");
+    expect(out).not.toContain(`directoryObjects/${aId}`);
+  });
+});
+
+describe("generateLocalTerraformBatchSnippet (method fidelity)", () => {
+  const POST_BATCH_REQUEST = JSON.stringify({
+    requests: [
+      {
+        id: "1",
+        method: "POST",
+        url: "/groups",
+        body: { displayName: "Engineering", mailNickname: "eng", appId: "should-keep" },
+      },
+    ],
+  });
+  const POST_BATCH_RESPONSE = JSON.stringify({
+    responses: [
+      {
+        id: "1",
+        status: 201,
+        body: {
+          "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#groups/$entity",
+          id: GUID,
+          displayName: "Engineering",
+          mailNickname: "eng",
+        },
+      },
+    ],
+  });
+
+  it("treats a POST sub-request as a real create: request body, no warning", () => {
+    const out = generateLocalTerraformBatchSnippet(POST_BATCH_REQUEST, POST_BATCH_RESPONSE);
+    expect(out).toContain('"group_engineering"');
+    expect(out).toContain('url = "groups"');
+    expect(out).not.toContain("# WARNING");
+    // request body is authoritative and kept as-is (not stripped like a GET response)
+    expect(out).toContain("appId");
+    expect(out).toContain("should-keep");
+  });
+
+  it("emits POST creates even without the experimental flag", () => {
+    const out = generateLocalTerraformBatchSnippet(POST_BATCH_REQUEST, POST_BATCH_RESPONSE);
+    expect(out).not.toBeNull();
+    expect(out).toContain('"group_engineering"');
+  });
+
+  it("suppresses GET-derived items when the flag is off but keeps POST creates", () => {
+    const requestBody = JSON.stringify({
+      requests: [
+        { id: "1", method: "POST", url: "/groups", body: { displayName: "Made" } },
+        { id: "2", method: "GET", url: "/users" },
+      ],
+    });
+    const responseBody = JSON.stringify({
+      responses: [
+        {
+          id: "1",
+          status: 201,
+          body: {
+            "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#groups/$entity",
+            id: GUID,
+            displayName: "Made",
+          },
+        },
+        {
+          id: "2",
+          status: 200,
+          body: {
+            "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users",
+            value: [{ id: "33333333-3333-3333-3333-333333333333", displayName: "Read" }],
+          },
+        },
+      ],
+    });
+    const off = generateLocalTerraformBatchSnippet(requestBody, responseBody, false);
+    expect(off).toContain('"group_made"');
+    expect(off).not.toContain('"user_read"');
+
+    const on = generateLocalTerraformBatchSnippet(requestBody, responseBody, true);
+    expect(on).toContain('"group_made"');
+    expect(on).toContain('"user_read"');
+  });
+
+  it("falls back to the response body when a create sub-request has no body", () => {
+    const requestBody = JSON.stringify({
+      requests: [{ id: "1", method: "POST", url: "/groups" }],
+    });
+    const responseBody = JSON.stringify({
+      responses: [
+        {
+          id: "1",
+          status: 201,
+          body: {
+            "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#groups/$entity",
+            id: GUID,
+            displayName: "FromResp",
+          },
+        },
+      ],
+    });
+    const out = generateLocalTerraformBatchSnippet(requestBody, responseBody);
+    expect(out).toContain('"group_from_resp"');
+    expect(out).not.toContain("# WARNING"); // still a create, no warning
   });
 });

--- a/src/common/client.test.js
+++ b/src/common/client.test.js
@@ -1,0 +1,571 @@
+import {
+  generateTerraformSnippet,
+  normalizeTerraformUrl,
+  stripReadOnlyFields,
+  formatHclValue,
+  formatHclString,
+  buildResourceLabel,
+  renderTerraformBlock,
+  prependGetWarning,
+  uniqueLabel,
+  sanitizeLabel,
+  shouldStripOdataKey,
+  hashUrl,
+  leafCollectionName,
+  tryParseJson,
+} from "./client.js";
+
+const GUID = "12345678-1234-1234-1234-123456789012";
+
+describe("tryParseJson", () => {
+  it("parses a JSON object", () => {
+    expect(tryParseJson('{"a":1}')).toEqual({ a: 1 });
+  });
+
+  it("parses a JSON array", () => {
+    expect(tryParseJson("[1,2,3]")).toEqual([1, 2, 3]);
+  });
+
+  it("trims surrounding whitespace before parsing", () => {
+    expect(tryParseJson('   {"a":1}   ')).toEqual({ a: 1 });
+  });
+
+  it("returns null for whitespace-only input", () => {
+    expect(tryParseJson("   ")).toBeNull();
+  });
+
+  it("returns null for an empty string", () => {
+    expect(tryParseJson("")).toBeNull();
+  });
+
+  it("returns null for null / non-string input", () => {
+    expect(tryParseJson(null)).toBeNull();
+    expect(tryParseJson(undefined)).toBeNull();
+    expect(tryParseJson(123)).toBeNull();
+    expect(tryParseJson({})).toBeNull();
+  });
+
+  it("returns null (does not throw) for malformed JSON", () => {
+    expect(tryParseJson("{not json}")).toBeNull();
+  });
+});
+
+describe("hashUrl", () => {
+  it("is deterministic for the same input", () => {
+    expect(hashUrl("https://graph.microsoft.com/v1.0/groups")).toBe(
+      hashUrl("https://graph.microsoft.com/v1.0/groups")
+    );
+  });
+
+  it("produces a short alphanumeric string of at most 6 chars", () => {
+    expect(hashUrl("some-seed-value")).toMatch(/^[a-z0-9]{1,6}$/);
+  });
+
+  it("produces different output for different input", () => {
+    expect(hashUrl("seed-a")).not.toBe(hashUrl("seed-b"));
+  });
+
+  it("handles the empty string", () => {
+    expect(hashUrl("")).toBe("0");
+  });
+});
+
+describe("sanitizeLabel", () => {
+  it("converts camelCase to snake_case", () => {
+    expect(sanitizeLabel("displayName")).toBe("display_name");
+  });
+
+  it("replaces spaces and symbols with underscores", () => {
+    expect(sanitizeLabel("Test Group!")).toBe("test_group");
+  });
+
+  it("strips leading and trailing underscores", () => {
+    expect(sanitizeLabel("  hello  ")).toBe("hello");
+    expect(sanitizeLabel("@@name@@")).toBe("name");
+  });
+
+  it("lowercases and keeps digits", () => {
+    expect(sanitizeLabel("Group123")).toBe("group123");
+  });
+
+  it("collapses runs of invalid characters into a single underscore", () => {
+    expect(sanitizeLabel("a---b...c")).toBe("a_b_c");
+  });
+
+  it("coerces non-string input via String()", () => {
+    expect(sanitizeLabel(42)).toBe("42");
+  });
+
+  it("returns an empty string when nothing valid remains", () => {
+    expect(sanitizeLabel("***")).toBe("");
+  });
+});
+
+describe("shouldStripOdataKey", () => {
+  it("matches an exact strip key", () => {
+    expect(shouldStripOdataKey("@odata.context")).toBe(true);
+    expect(shouldStripOdataKey("@odata.etag")).toBe(true);
+  });
+
+  it("matches a property-scoped suffix (foo@odata.etag)", () => {
+    expect(shouldStripOdataKey("photo@odata.mediaEtag")).toBe(true);
+  });
+
+  it("keeps @odata.type discriminators", () => {
+    expect(shouldStripOdataKey("@odata.type")).toBe(false);
+  });
+
+  it("keeps *@odata.bind references", () => {
+    expect(shouldStripOdataKey("members@odata.bind")).toBe(false);
+    expect(shouldStripOdataKey("@odata.bind")).toBe(false);
+  });
+
+  it("returns false for ordinary keys", () => {
+    expect(shouldStripOdataKey("displayName")).toBe(false);
+  });
+});
+
+describe("stripReadOnlyFields", () => {
+  it("removes top-level read-only keys", () => {
+    const input = {
+      id: GUID,
+      createdDateTime: "2020-01-01",
+      deletedDateTime: "2020-01-02",
+      renewedDateTime: "2020-01-03",
+      modifiedDateTime: "2020-01-04",
+      displayName: "keep",
+    };
+    expect(stripReadOnlyFields(input)).toEqual({ displayName: "keep" });
+  });
+
+  it("keeps read-only keys when nested (depth > 0)", () => {
+    const input = { owner: { id: "keep-me", displayName: "o" } };
+    expect(stripReadOnlyFields(input)).toEqual({
+      owner: { id: "keep-me", displayName: "o" },
+    });
+  });
+
+  it("strips @odata.* annotation keys at any depth", () => {
+    const input = {
+      "@odata.context": "ctx",
+      nested: { "@odata.etag": "e", name: "n" },
+    };
+    expect(stripReadOnlyFields(input)).toEqual({ nested: { name: "n" } });
+  });
+
+  it("preserves @odata.type and @odata.bind at any depth", () => {
+    const input = {
+      "@odata.type": "#microsoft.graph.user",
+      nested: { "members@odata.bind": ["url"] },
+    };
+    expect(stripReadOnlyFields(input)).toEqual({
+      "@odata.type": "#microsoft.graph.user",
+      nested: { "members@odata.bind": ["url"] },
+    });
+  });
+
+  it("recurses through arrays of objects", () => {
+    const input = { items: [{ "@odata.etag": "x", v: 1 }, { v: 2 }] };
+    expect(stripReadOnlyFields(input)).toEqual({ items: [{ v: 1 }, { v: 2 }] });
+  });
+
+  it("passes primitives and null through unchanged", () => {
+    expect(stripReadOnlyFields("str")).toBe("str");
+    expect(stripReadOnlyFields(7)).toBe(7);
+    expect(stripReadOnlyFields(null)).toBeNull();
+  });
+});
+
+describe("formatHclString", () => {
+  it("wraps a plain string in quotes", () => {
+    expect(formatHclString("hello")).toBe('"hello"');
+  });
+
+  it("escapes backslashes, quotes, newlines, carriage returns and tabs", () => {
+    expect(formatHclString('a\\b"c\nd\re\tf')).toBe('"a\\\\b\\"c\\nd\\re\\tf"');
+  });
+
+  it("coerces non-string input", () => {
+    expect(formatHclString(5)).toBe('"5"');
+  });
+});
+
+describe("formatHclValue", () => {
+  it("renders null and undefined as null", () => {
+    expect(formatHclValue(null, "")).toBe("null");
+    expect(formatHclValue(undefined, "")).toBe("null");
+  });
+
+  it("renders booleans", () => {
+    expect(formatHclValue(true, "")).toBe("true");
+    expect(formatHclValue(false, "")).toBe("false");
+  });
+
+  it("renders numbers as-is", () => {
+    expect(formatHclValue(42, "")).toBe("42");
+  });
+
+  it("delegates strings to HCL escaping", () => {
+    expect(formatHclValue('say "hi"', "")).toBe('"say \\"hi\\""');
+  });
+
+  it("renders an empty array and empty object compactly", () => {
+    expect(formatHclValue([], "")).toBe("[]");
+    expect(formatHclValue({}, "")).toBe("{}");
+  });
+
+  it("renders a non-empty array with indentation", () => {
+    expect(formatHclValue(["a", "b"], "")).toBe('[\n  "a",\n  "b",\n]');
+  });
+
+  it("aligns object keys by width", () => {
+    expect(formatHclValue({ a: 1, bbb: 2 }, "")).toBe(
+      "{\n  a   = 1\n  bbb = 2\n}"
+    );
+  });
+
+  it("quotes non-identifier keys and leaves identifier keys bare", () => {
+    const out = formatHclValue({ "@odata.type": "#x", name: "n" }, "");
+    expect(out).toContain('"@odata.type"');
+    expect(out).toContain('name');
+    expect(out).not.toContain('"name"');
+  });
+
+  it("renders nested structures", () => {
+    const out = formatHclValue({ outer: { inner: [1] } }, "");
+    expect(out).toBe("{\n  outer = {\n    inner = [\n      1,\n    ]\n  }\n}");
+  });
+});
+
+describe("normalizeTerraformUrl", () => {
+  it("strips the v1.0 prefix and reports no api version", () => {
+    expect(
+      normalizeTerraformUrl("https://graph.microsoft.com/v1.0/groups")
+    ).toEqual({ url: "groups", apiVersion: null });
+  });
+
+  it("detects the beta prefix as an api version", () => {
+    expect(
+      normalizeTerraformUrl("https://graph.microsoft.com/beta/groups")
+    ).toEqual({ url: "groups", apiVersion: "beta" });
+  });
+
+  it("matches the version prefix case-insensitively", () => {
+    expect(
+      normalizeTerraformUrl("https://graph.microsoft.com/V1.0/groups")
+    ).toEqual({ url: "groups", apiVersion: null });
+  });
+
+  it("drops a trailing GUID when there is more than one segment", () => {
+    expect(
+      normalizeTerraformUrl(`https://graph.microsoft.com/v1.0/groups/${GUID}`)
+    ).toEqual({ url: "groups", apiVersion: null });
+  });
+
+  it("keeps a lone GUID segment (only trims when >1 segment)", () => {
+    expect(
+      normalizeTerraformUrl(`https://graph.microsoft.com/v1.0/${GUID}`)
+    ).toEqual({ url: GUID, apiVersion: null });
+  });
+
+  it("removes the query string", () => {
+    expect(
+      normalizeTerraformUrl(
+        "https://graph.microsoft.com/v1.0/groups?$select=id,displayName"
+      )
+    ).toEqual({ url: "groups", apiVersion: null });
+  });
+
+  it("handles a relative path with no recognised domain", () => {
+    expect(
+      normalizeTerraformUrl(`/v1.0/users/${GUID}`)
+    ).toEqual({ url: "users", apiVersion: null });
+  });
+
+  it("preserves nested resource paths", () => {
+    expect(
+      normalizeTerraformUrl(
+        `https://graph.microsoft.com/v1.0/groups/${GUID}/members`
+      )
+    ).toEqual({ url: `groups/${GUID}/members`, apiVersion: null });
+  });
+});
+
+describe("leafCollectionName", () => {
+  it("returns the single segment", () => {
+    expect(leafCollectionName("groups")).toBe("groups");
+  });
+
+  it("returns the last non-GUID segment", () => {
+    expect(leafCollectionName(`groups/${GUID}/members`)).toBe("members");
+  });
+
+  it("skips a trailing GUID", () => {
+    expect(leafCollectionName(`groups/${GUID}`)).toBe("groups");
+  });
+
+  it("ignores $-prefixed segments", () => {
+    expect(leafCollectionName("groups/$count")).toBe("groups");
+  });
+
+  it("returns empty string when there is no collection", () => {
+    expect(leafCollectionName("")).toBe("");
+  });
+});
+
+describe("buildResourceLabel", () => {
+  const singulars = {
+    groups: "group",
+    users: "user",
+    applications: "application",
+    servicePrincipals: "service_principal",
+    oauth2PermissionGrants: "oauth2_permission_grant",
+    appRoleAssignedTo: "app_role_assignment",
+    federatedIdentityCredentials: "federated_identity_credential",
+    devices: "device",
+    contacts: "contact",
+  };
+
+  Object.entries(singulars).forEach(([collection, singular]) => {
+    it(`maps the "${collection}" collection to the "${singular}" prefix`, () => {
+      expect(buildResourceLabel(collection, { displayName: "X" }, "seed")).toBe(
+        `${singular}_x`
+      );
+    });
+  });
+
+  it("falls back to sanitizeLabel for an unknown collection", () => {
+    expect(
+      buildResourceLabel("widgets", { displayName: "My Thing" }, "seed")
+    ).toBe("widgets_my_thing"); // sanitizeLabel("widgets") === "widgets"
+  });
+
+  it("uses the 'resource' prefix when no collection name is present", () => {
+    expect(buildResourceLabel("", {}, "seed")).toBe(`resource_${hashUrl("seed")}`);
+  });
+
+  it("prefers displayName over the other name candidates", () => {
+    expect(
+      buildResourceLabel(
+        "groups",
+        { displayName: "Primary", mailNickname: "nick", name: "n" },
+        "seed"
+      )
+    ).toBe("group_primary");
+  });
+
+  it("falls through the candidate priority: mailNickname, then userPrincipalName, then name", () => {
+    expect(buildResourceLabel("groups", { mailNickname: "nick" }, "s")).toBe(
+      "group_nick"
+    );
+    expect(
+      buildResourceLabel("users", { userPrincipalName: "upn@contoso" }, "s")
+    ).toBe("user_upn_contoso");
+    expect(buildResourceLabel("contacts", { name: "Bob" }, "s")).toBe(
+      "contact_bob"
+    );
+  });
+
+  it("skips empty / whitespace-only candidates", () => {
+    expect(
+      buildResourceLabel("groups", { displayName: "   ", mailNickname: "nick" }, "s")
+    ).toBe("group_nick");
+  });
+
+  it("uses a deterministic hash fallback when no name candidate is found", () => {
+    const seed = "https://graph.microsoft.com/v1.0/groups#0";
+    expect(buildResourceLabel("groups", { foo: "bar" }, seed)).toBe(
+      `group_${hashUrl(seed)}`
+    );
+    expect(buildResourceLabel("groups", { foo: "bar" }, seed)).toBe(
+      buildResourceLabel("groups", { foo: "bar" }, seed)
+    );
+  });
+});
+
+describe("renderTerraformBlock", () => {
+  it("renders url and body and omits api_version when not set", () => {
+    const block = renderTerraformBlock("group_x", "groups", null, {
+      displayName: "X",
+    });
+    expect(block).toBe(
+      'resource "msgraph_resource" "group_x" {\n' +
+        '  url = "groups"\n' +
+        "  body = {\n" +
+        '    displayName = "X"\n' +
+        "  }\n" +
+        "}"
+    );
+  });
+
+  it("includes an api_version line when set", () => {
+    const block = renderTerraformBlock("group_x", "groups", "beta", {
+      displayName: "X",
+    });
+    expect(block).toContain('  api_version = "beta"');
+  });
+});
+
+describe("prependGetWarning", () => {
+  it("prepends the three warning comment lines above the block", () => {
+    const result = prependGetWarning("BLOCK");
+    const lines = result.split("\n");
+    expect(lines[0]).toBe(
+      "# WARNING: Generated from a GET response - review before apply."
+    );
+    expect(lines[1]).toMatch(/^# Read-only/);
+    expect(lines[2]).toMatch(/^# verify/);
+    expect(lines[3]).toBe("BLOCK");
+  });
+});
+
+describe("uniqueLabel", () => {
+  it("returns the base label on first use and records it", () => {
+    const used = new Set();
+    expect(uniqueLabel("group_x", used)).toBe("group_x");
+    expect(used.has("group_x")).toBe(true);
+  });
+
+  it("suffixes _2, _3 on subsequent collisions", () => {
+    const used = new Set();
+    expect(uniqueLabel("group_x", used)).toBe("group_x");
+    expect(uniqueLabel("group_x", used)).toBe("group_x_2");
+    expect(uniqueLabel("group_x", used)).toBe("group_x_3");
+  });
+});
+
+describe("generateTerraformSnippet", () => {
+  const URL = "https://graph.microsoft.com/v1.0/groups";
+
+  it("returns null for DELETE and OPTIONS", () => {
+    expect(generateTerraformSnippet("DELETE", URL, "{}", "")).toBeNull();
+    expect(generateTerraformSnippet("OPTIONS", URL, "{}", "")).toBeNull();
+  });
+
+  it("returns null for GET without the experimental flag", () => {
+    expect(
+      generateTerraformSnippet("GET", URL, "", '{"displayName":"X"}')
+    ).toBeNull();
+  });
+
+  it("generates a block from a GET response when the experimental flag is set, with a warning", () => {
+    const out = generateTerraformSnippet(
+      "GET",
+      URL,
+      "",
+      `{"id":"${GUID}","displayName":"X"}`,
+      true
+    );
+    expect(out).toContain("# WARNING: Generated from a GET response");
+    expect(out).toContain('resource "msgraph_resource" "group_x"');
+    expect(out).not.toContain(GUID); // read-only id stripped
+  });
+
+  it("produces an exact HCL block for a POST create", () => {
+    const out = generateTerraformSnippet(
+      "POST",
+      URL,
+      '{"displayName":"Marketing"}',
+      ""
+    );
+    expect(out).toBe(
+      'resource "msgraph_resource" "group_marketing" {\n' +
+        '  url = "groups"\n' +
+        "  body = {\n" +
+        '    displayName = "Marketing"\n' +
+        "  }\n" +
+        "}"
+    );
+  });
+
+  it("does not add a warning for non-GET methods", () => {
+    const out = generateTerraformSnippet(
+      "PATCH",
+      URL,
+      '{"displayName":"X"}',
+      ""
+    );
+    expect(out).not.toContain("WARNING");
+  });
+
+  it("falls back to responseBody for non-GET when requestBody is empty", () => {
+    const out = generateTerraformSnippet("POST", URL, "", '{"displayName":"X"}');
+    expect(out).toContain('resource "msgraph_resource" "group_x"');
+  });
+
+  it("falls back to requestBody for GET when responseBody is empty", () => {
+    const out = generateTerraformSnippet(
+      "GET",
+      URL,
+      '{"displayName":"X"}',
+      "",
+      true
+    );
+    expect(out).toContain('resource "msgraph_resource" "group_x"');
+  });
+
+  it("returns null for invalid / empty JSON", () => {
+    expect(generateTerraformSnippet("POST", URL, "not json", "")).toBeNull();
+    expect(generateTerraformSnippet("POST", URL, "", "")).toBeNull();
+  });
+
+  it("returns null for primitive (non-object) JSON", () => {
+    expect(generateTerraformSnippet("POST", URL, "123", "")).toBeNull();
+    expect(generateTerraformSnippet("POST", URL, '"a string"', "")).toBeNull();
+  });
+
+  it("emits one block per item for a collection response", () => {
+    const out = generateTerraformSnippet(
+      "GET",
+      URL,
+      "",
+      '{"value":[{"displayName":"Alpha"},{"displayName":"Beta"}]}',
+      true
+    );
+    const blocks = out.split("\n\n");
+    expect(blocks).toHaveLength(2);
+    expect(out).toContain('"group_alpha"');
+    expect(out).toContain('"group_beta"');
+  });
+
+  it("strips read-only and @odata fields from output", () => {
+    const out = generateTerraformSnippet(
+      "POST",
+      URL,
+      `{"@odata.context":"ctx","id":"${GUID}","displayName":"X"}`,
+      ""
+    );
+    expect(out).not.toContain("@odata.context");
+    expect(out).not.toContain(GUID);
+    expect(out).toContain('displayName = "X"');
+  });
+
+  it("returns null when every item is empty after stripping", () => {
+    expect(generateTerraformSnippet("POST", URL, `{"id":"${GUID}"}`, "")).toBeNull();
+  });
+
+  it("de-duplicates labels across collection items", () => {
+    const out = generateTerraformSnippet(
+      "GET",
+      URL,
+      "",
+      '{"value":[{"displayName":"Dup"},{"displayName":"Dup"}]}',
+      true
+    );
+    expect(out).toContain('"group_dup"');
+    expect(out).toContain('"group_dup_2"');
+  });
+
+  it("emits api_version for a beta URL and omits it for v1.0", () => {
+    const beta = generateTerraformSnippet(
+      "POST",
+      "https://graph.microsoft.com/beta/groups",
+      '{"displayName":"X"}',
+      ""
+    );
+    expect(beta).toContain('api_version = "beta"');
+
+    const v1 = generateTerraformSnippet("POST", URL, '{"displayName":"X"}', "");
+    expect(v1).not.toContain("api_version");
+  });
+});

--- a/src/common/client.test.js
+++ b/src/common/client.test.js
@@ -1,5 +1,5 @@
 import {
-  generateTerraformSnippet,
+  generateLocalTerraformSnippet,
   normalizeTerraformUrl,
   stripReadOnlyFields,
   formatHclValue,
@@ -14,7 +14,7 @@ import {
   leafCollectionName,
   tryParseJson,
   parseODataContext,
-  generateTerraformBatchSnippet,
+  generateLocalTerraformBatchSnippet,
 } from "./client.js";
 
 const GUID = "12345678-1234-1234-1234-123456789012";
@@ -436,22 +436,22 @@ describe("uniqueLabel", () => {
   });
 });
 
-describe("generateTerraformSnippet", () => {
+describe("generateLocalTerraformSnippet", () => {
   const URL = "https://graph.microsoft.com/v1.0/groups";
 
   it("returns null for DELETE and OPTIONS", () => {
-    expect(generateTerraformSnippet("DELETE", URL, "{}", "")).toBeNull();
-    expect(generateTerraformSnippet("OPTIONS", URL, "{}", "")).toBeNull();
+    expect(generateLocalTerraformSnippet("DELETE", URL, "{}", "")).toBeNull();
+    expect(generateLocalTerraformSnippet("OPTIONS", URL, "{}", "")).toBeNull();
   });
 
   it("returns null for GET without the experimental flag", () => {
     expect(
-      generateTerraformSnippet("GET", URL, "", '{"displayName":"X"}')
+      generateLocalTerraformSnippet("GET", URL, "", '{"displayName":"X"}')
     ).toBeNull();
   });
 
   it("generates a block from a GET response when the experimental flag is set, with a warning", () => {
-    const out = generateTerraformSnippet(
+    const out = generateLocalTerraformSnippet(
       "GET",
       URL,
       "",
@@ -464,7 +464,7 @@ describe("generateTerraformSnippet", () => {
   });
 
   it("produces an exact HCL block for a POST create", () => {
-    const out = generateTerraformSnippet(
+    const out = generateLocalTerraformSnippet(
       "POST",
       URL,
       '{"displayName":"Marketing"}',
@@ -481,7 +481,7 @@ describe("generateTerraformSnippet", () => {
   });
 
   it("does not add a warning for non-GET methods", () => {
-    const out = generateTerraformSnippet(
+    const out = generateLocalTerraformSnippet(
       "PATCH",
       URL,
       '{"displayName":"X"}',
@@ -491,12 +491,12 @@ describe("generateTerraformSnippet", () => {
   });
 
   it("falls back to responseBody for non-GET when requestBody is empty", () => {
-    const out = generateTerraformSnippet("POST", URL, "", '{"displayName":"X"}');
+    const out = generateLocalTerraformSnippet("POST", URL, "", '{"displayName":"X"}');
     expect(out).toContain('resource "msgraph_resource" "group_x"');
   });
 
   it("falls back to requestBody for GET when responseBody is empty", () => {
-    const out = generateTerraformSnippet(
+    const out = generateLocalTerraformSnippet(
       "GET",
       URL,
       '{"displayName":"X"}',
@@ -507,17 +507,17 @@ describe("generateTerraformSnippet", () => {
   });
 
   it("returns null for invalid / empty JSON", () => {
-    expect(generateTerraformSnippet("POST", URL, "not json", "")).toBeNull();
-    expect(generateTerraformSnippet("POST", URL, "", "")).toBeNull();
+    expect(generateLocalTerraformSnippet("POST", URL, "not json", "")).toBeNull();
+    expect(generateLocalTerraformSnippet("POST", URL, "", "")).toBeNull();
   });
 
   it("returns null for primitive (non-object) JSON", () => {
-    expect(generateTerraformSnippet("POST", URL, "123", "")).toBeNull();
-    expect(generateTerraformSnippet("POST", URL, '"a string"', "")).toBeNull();
+    expect(generateLocalTerraformSnippet("POST", URL, "123", "")).toBeNull();
+    expect(generateLocalTerraformSnippet("POST", URL, '"a string"', "")).toBeNull();
   });
 
   it("emits one block per item for a collection response", () => {
-    const out = generateTerraformSnippet(
+    const out = generateLocalTerraformSnippet(
       "GET",
       URL,
       "",
@@ -531,7 +531,7 @@ describe("generateTerraformSnippet", () => {
   });
 
   it("strips read-only and @odata fields from output", () => {
-    const out = generateTerraformSnippet(
+    const out = generateLocalTerraformSnippet(
       "POST",
       URL,
       `{"@odata.context":"ctx","id":"${GUID}","displayName":"X"}`,
@@ -543,11 +543,11 @@ describe("generateTerraformSnippet", () => {
   });
 
   it("returns null when every item is empty after stripping", () => {
-    expect(generateTerraformSnippet("POST", URL, `{"id":"${GUID}"}`, "")).toBeNull();
+    expect(generateLocalTerraformSnippet("POST", URL, `{"id":"${GUID}"}`, "")).toBeNull();
   });
 
   it("de-duplicates labels across collection items", () => {
-    const out = generateTerraformSnippet(
+    const out = generateLocalTerraformSnippet(
       "GET",
       URL,
       "",
@@ -559,7 +559,7 @@ describe("generateTerraformSnippet", () => {
   });
 
   it("emits api_version for a beta URL and omits it for v1.0", () => {
-    const beta = generateTerraformSnippet(
+    const beta = generateLocalTerraformSnippet(
       "POST",
       "https://graph.microsoft.com/beta/groups",
       '{"displayName":"X"}',
@@ -567,7 +567,7 @@ describe("generateTerraformSnippet", () => {
     );
     expect(beta).toContain('api_version = "beta"');
 
-    const v1 = generateTerraformSnippet("POST", URL, '{"displayName":"X"}', "");
+    const v1 = generateLocalTerraformSnippet("POST", URL, '{"displayName":"X"}', "");
     expect(v1).not.toContain("api_version");
   });
 });
@@ -660,21 +660,21 @@ const IDENTITY_PROVIDERS_BATCH = JSON.stringify({
   ],
 });
 
-describe("generateTerraformBatchSnippet", () => {
+describe("generateLocalTerraformBatchSnippet", () => {
   it("generates one adopt block per resource in the provided identityProviders payload", () => {
-    const out = generateTerraformBatchSnippet("", IDENTITY_PROVIDERS_BATCH);
+    const out = generateLocalTerraformBatchSnippet("", IDENTITY_PROVIDERS_BATCH);
     const blocks = out.split("\n\n");
     expect(blocks).toHaveLength(2);
   });
 
   it("derives url and beta api_version from @odata.context", () => {
-    const out = generateTerraformBatchSnippet("", IDENTITY_PROVIDERS_BATCH);
+    const out = generateLocalTerraformBatchSnippet("", IDENTITY_PROVIDERS_BATCH);
     expect(out).toContain('url = "identity/identityProviders"');
     expect(out).toContain('api_version = "beta"');
   });
 
   it("preserves @odata.type discriminators and strips read-only ids", () => {
-    const out = generateTerraformBatchSnippet("", IDENTITY_PROVIDERS_BATCH);
+    const out = generateLocalTerraformBatchSnippet("", IDENTITY_PROVIDERS_BATCH);
     // (HCL aligns the `=`, so match the quoted key + value without assuming spacing)
     expect(out).toContain('"@odata.type"');
     expect(out).toContain('"#microsoft.graph.oidcIdentityProvider"');
@@ -685,26 +685,26 @@ describe("generateTerraformBatchSnippet", () => {
   });
 
   it("keeps non-read-only fields such as clientSecret", () => {
-    const out = generateTerraformBatchSnippet("", IDENTITY_PROVIDERS_BATCH);
+    const out = generateLocalTerraformBatchSnippet("", IDENTITY_PROVIDERS_BATCH);
     expect(out).toMatch(/clientSecret\s+=\s+"\*{6}"/);
   });
 
   it("prepends a GET/adopt warning to every block", () => {
-    const out = generateTerraformBatchSnippet("", IDENTITY_PROVIDERS_BATCH);
+    const out = generateLocalTerraformBatchSnippet("", IDENTITY_PROVIDERS_BATCH);
     const warnings = out.match(/# WARNING: Generated from a GET response/g);
     expect(warnings).toHaveLength(2);
   });
 
   it("derives labels from displayName", () => {
-    const out = generateTerraformBatchSnippet("", IDENTITY_PROVIDERS_BATCH);
+    const out = generateLocalTerraformBatchSnippet("", IDENTITY_PROVIDERS_BATCH);
     expect(out).toContain('"identity_providers_facebook"');
     expect(out).toContain('"identity_providers_workforce_entra_id"');
   });
 
   it("returns null for an invalid or non-batch response envelope", () => {
-    expect(generateTerraformBatchSnippet("", "not json")).toBeNull();
-    expect(generateTerraformBatchSnippet("", "{}")).toBeNull();
-    expect(generateTerraformBatchSnippet("", '{"value":[]}')).toBeNull();
+    expect(generateLocalTerraformBatchSnippet("", "not json")).toBeNull();
+    expect(generateLocalTerraformBatchSnippet("", "{}")).toBeNull();
+    expect(generateLocalTerraformBatchSnippet("", '{"value":[]}')).toBeNull();
   });
 
   it("skips non-2xx sub-responses", () => {
@@ -728,7 +728,7 @@ describe("generateTerraformBatchSnippet", () => {
         },
       ],
     });
-    const out = generateTerraformBatchSnippet("", envelope);
+    const out = generateLocalTerraformBatchSnippet("", envelope);
     expect(out).toContain('"group_present"');
     expect(out).not.toContain("Missing");
   });
@@ -747,7 +747,7 @@ describe("generateTerraformBatchSnippet", () => {
         },
       ],
     });
-    const out = generateTerraformBatchSnippet("", envelope);
+    const out = generateLocalTerraformBatchSnippet("", envelope);
     expect(out.split("\n\n")).toHaveLength(1);
     expect(out).toContain('"group_solo"');
     expect(out).toContain('url = "groups"');
@@ -761,7 +761,7 @@ describe("generateTerraformBatchSnippet", () => {
     const responseBody = JSON.stringify({
       responses: [{ id: "42", status: 200, body: { displayName: "FromReq" } }],
     });
-    const out = generateTerraformBatchSnippet(requestBody, responseBody);
+    const out = generateLocalTerraformBatchSnippet(requestBody, responseBody);
     expect(out).toContain('url = "groups"');
     expect(out).toContain('"group_from_req"'); // sanitizeLabel("FromReq") -> from_req
   });
@@ -773,7 +773,7 @@ describe("generateTerraformBatchSnippet", () => {
       ],
     });
     // no @odata.context and no matching request => skipped
-    expect(generateTerraformBatchSnippet("", responseBody)).toBeNull();
+    expect(generateLocalTerraformBatchSnippet("", responseBody)).toBeNull();
   });
 
   it("skips an item that is empty after stripping read-only fields", () => {
@@ -789,7 +789,7 @@ describe("generateTerraformBatchSnippet", () => {
         },
       ],
     });
-    expect(generateTerraformBatchSnippet("", responseBody)).toBeNull();
+    expect(generateLocalTerraformBatchSnippet("", responseBody)).toBeNull();
   });
 
   it("de-duplicates labels across responses", () => {
@@ -813,17 +813,17 @@ describe("generateTerraformBatchSnippet", () => {
         },
       ],
     });
-    const out = generateTerraformBatchSnippet("", responseBody);
+    const out = generateLocalTerraformBatchSnippet("", responseBody);
     expect(out).toContain('"group_dup"');
     expect(out).toContain('"group_dup_2"');
   });
 });
 
-describe("generateTerraformSnippet ($batch integration)", () => {
+describe("generateLocalTerraformSnippet ($batch integration)", () => {
   const BATCH_URL = "https://graph.microsoft.com/beta/$batch";
 
   it("produces adopt blocks for a $batch when the experimental flag is set", () => {
-    const out = generateTerraformSnippet(
+    const out = generateLocalTerraformSnippet(
       "POST",
       BATCH_URL,
       "",
@@ -836,7 +836,7 @@ describe("generateTerraformSnippet ($batch integration)", () => {
 
   it("returns null for a $batch without the experimental flag", () => {
     expect(
-      generateTerraformSnippet("POST", BATCH_URL, "", IDENTITY_PROVIDERS_BATCH)
+      generateLocalTerraformSnippet("POST", BATCH_URL, "", IDENTITY_PROVIDERS_BATCH)
     ).toBeNull();
   });
 
@@ -844,7 +844,7 @@ describe("generateTerraformSnippet ($batch integration)", () => {
     const requestBody = JSON.stringify({
       requests: [{ id: "1", method: "GET", url: "/identity/identityProviders" }],
     });
-    const out = generateTerraformSnippet(
+    const out = generateLocalTerraformSnippet(
       "POST",
       BATCH_URL,
       requestBody,

--- a/src/components/AppHeader.js
+++ b/src/components/AppHeader.js
@@ -3,6 +3,22 @@ import { DefaultPalette } from "@fluentui/react";
 import { FontSizes } from "@fluentui/theme";
 import { CommandMenu } from "./CommandMenu.js";
 
+// Set at build time by the dedicated `npm run build:dev` script (via DefinePlugin).
+// Undefined in production builds, so the DEV badge never renders there.
+const isDevBuild = process.env.REACT_APP_DEV_BUILD === "true";
+
+const devBadgeStyle = {
+  marginLeft: 8,
+  padding: "1px 6px",
+  borderRadius: 4,
+  background: DefaultPalette.orangeLight,
+  color: DefaultPalette.white,
+  fontSize: FontSizes.size12,
+  fontWeight: 600,
+  textTransform: "uppercase",
+  letterSpacing: 0.5,
+};
+
 // Non-mutating styles definition
 const stackItemStyles = {
   root: {
@@ -39,9 +55,12 @@ export const AppHeader = ({ hideSettings }) => {
           style={{
             fontSize: FontSizes.size16,
             fontWeight: 600,
+            display: "flex",
+            alignItems: "center",
           }}
         >
           Microsoft Graph X-Ray
+          {isDevBuild && <span style={devBadgeStyle}>DEV Build</span>}
         </div>
       </Stack.Item>
       <Stack.Item grow styles={stackItemStyles}>

--- a/src/components/CodeView.js
+++ b/src/components/CodeView.js
@@ -1,12 +1,87 @@
 import React, { useState } from "react";
-import SyntaxHighlighter from "react-syntax-highlighter";
+import SyntaxHighlighter, { createElement } from "react-syntax-highlighter";
 import {
   atomOneDark,
   atomOneLight,
 } from "react-syntax-highlighter/dist/esm/styles/hljs";
 import { IconButton } from "@fluentui/react/lib/Button";
 
-const ColoredUrl = ({ url }) => {
+// Split plain text and wrap case-insensitive matches of `query` in a highlight
+// marker. Returns the original string when there is no query/match so callers
+// can use it transparently inside JSX text positions.
+const highlightText = (text, query) => {
+  if (typeof text !== "string" || !query) return text;
+  const q = query.trim();
+  if (!q) return text;
+  const escaped = q.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const segments = text.split(new RegExp(`(${escaped})`, "gi"));
+  if (segments.length === 1) return text;
+  // String.split with a capturing group yields matches at odd indices.
+  return segments.map((seg, i) =>
+    i % 2 === 1 ? (
+      <mark key={i} className="gxr-search-hit">{seg}</mark>
+    ) : (
+      seg
+    )
+  );
+};
+
+// Custom react-syntax-highlighter renderer that wraps case-insensitive matches
+// of `query` in a <mark> by transforming the token tree before it is rendered.
+// Matching is token-level (a contiguous GUID/objectId/appId lives in one token).
+const buildHighlightRenderer = (query) => {
+  const q = (query || "").trim();
+  const lower = q.toLowerCase();
+
+  const splitTextNode = (value) => {
+    if (!q) return [{ type: "text", value }];
+    const lowerVal = value.toLowerCase();
+    const out = [];
+    let idx = 0;
+    let pos = lowerVal.indexOf(lower);
+    if (pos === -1) return [{ type: "text", value }];
+    while (pos !== -1) {
+      if (pos > idx) out.push({ type: "text", value: value.slice(idx, pos) });
+      out.push({
+        type: "element",
+        tagName: "mark",
+        properties: { className: ["gxr-search-hit"] },
+        children: [{ type: "text", value: value.slice(pos, pos + q.length) }],
+      });
+      idx = pos + q.length;
+      pos = lowerVal.indexOf(lower, idx);
+    }
+    if (idx < value.length) out.push({ type: "text", value: value.slice(idx) });
+    return out;
+  };
+
+  const transform = (node) => {
+    if (node.type === "text") return splitTextNode(node.value);
+    if (node.children) {
+      const children = [];
+      node.children.forEach((child) => {
+        const res = transform(child);
+        if (Array.isArray(res)) children.push(...res);
+        else children.push(res);
+      });
+      return { ...node, children };
+    }
+    return node;
+  };
+
+  return ({ rows, stylesheet, useInlineStyles }) =>
+    rows.map((node, i) =>
+      createElement({
+        node: transform(node),
+        stylesheet,
+        useInlineStyles,
+        key: `gxr-row-${i}`,
+      })
+    );
+};
+
+const ColoredUrl = ({ url, query }) => {
+  const hl = (text) => highlightText(text, query);
   const parts = [];
   try {
     // PowerShell escapes $ as `$ in URLs — clean for parsing, preserve in output
@@ -21,7 +96,7 @@ const ColoredUrl = ({ url }) => {
     parts.push(<span key="proto" className="gxr-url-protocol">{urlObj.protocol}{"//"}</span>);
 
     // Host
-    parts.push(<span key="host" className="gxr-url-host">{urlObj.host}</span>);
+    parts.push(<span key="host" className="gxr-url-host">{hl(urlObj.host)}</span>);
 
     // Path segments
     const pathSegments = urlObj.pathname.split("/").filter(Boolean);
@@ -30,7 +105,7 @@ const ColoredUrl = ({ url }) => {
       if (/^(v1\.0|beta)$/i.test(seg)) {
         parts.push(<span key={`seg-${i}`} className="gxr-url-version">{seg}</span>);
       } else {
-        parts.push(<span key={`seg-${i}`} className="gxr-url-path">{seg}</span>);
+        parts.push(<span key={`seg-${i}`} className="gxr-url-path">{hl(seg)}</span>);
       }
     });
 
@@ -45,22 +120,22 @@ const ColoredUrl = ({ url }) => {
         }
         const eqIndex = param.indexOf("=");
         if (eqIndex >= 0) {
-          parts.push(<span key={`q-key-${i}`} className="gxr-url-query-key">{preserve(decodeURIComponent(param.slice(0, eqIndex)))}</span>);
+          parts.push(<span key={`q-key-${i}`} className="gxr-url-query-key">{hl(preserve(decodeURIComponent(param.slice(0, eqIndex))))}</span>);
           parts.push(<span key={`q-eq-${i}`} className="gxr-url-query-punctuation">=</span>);
-          parts.push(<span key={`q-val-${i}`} className="gxr-url-query-value">{preserve(decodeURIComponent(param.slice(eqIndex + 1)))}</span>);
+          parts.push(<span key={`q-val-${i}`} className="gxr-url-query-value">{hl(preserve(decodeURIComponent(param.slice(eqIndex + 1))))}</span>);
         } else {
-          parts.push(<span key={`q-key-${i}`} className="gxr-url-query-key">{preserve(decodeURIComponent(param))}</span>);
+          parts.push(<span key={`q-key-${i}`} className="gxr-url-query-key">{hl(preserve(decodeURIComponent(param)))}</span>);
         }
       });
     }
   } catch {
     // Fallback for malformed URLs
-    return <span style={{ color: "#abb2bf" }}>{url}</span>;
+    return <span style={{ color: "#abb2bf" }}>{hl(url)}</span>;
   }
   return <>{parts}</>;
 };
 
-const ColoredCode = ({ code }) => {
+const ColoredCode = ({ code, query }) => {
   // Split code around URLs, rendering URLs with ColoredUrl and the rest as styled code
   // Also capture `$ (PowerShell backtick-dollar escaping) as part of the URL
   const urlRegex = /(https?:\/\/(?:[^\s"'`]|`\$)+)/g;
@@ -73,7 +148,7 @@ const ColoredCode = ({ code }) => {
     // Text before the URL
     if (match.index > lastIndex) {
       result.push(
-        <span key={key++} className="gxr-code-text">{code.slice(lastIndex, match.index)}</span>
+        <span key={key++} className="gxr-code-text">{highlightText(code.slice(lastIndex, match.index), query)}</span>
       );
     }
     // Strip surrounding quotes from the matched URL if present
@@ -81,7 +156,7 @@ const ColoredCode = ({ code }) => {
     // Remove trailing quote chars that may have been captured
     url = url.replace(/["'`]+$/, "");
     result.push(
-      <span key={key++} className="gxr-code-url"><ColoredUrl url={url} /></span>
+      <span key={key++} className="gxr-code-url"><ColoredUrl url={url} query={query} /></span>
     );
     lastIndex = match.index + match[0].length;
   }
@@ -89,19 +164,24 @@ const ColoredCode = ({ code }) => {
   // Remaining text after the last URL
   if (lastIndex < code.length) {
     result.push(
-      <span key={key++} className="gxr-code-text">{code.slice(lastIndex)}</span>
+      <span key={key++} className="gxr-code-text">{highlightText(code.slice(lastIndex), query)}</span>
     );
   }
 
   return <>{result}</>;
 };
 
-export const CodeView = ({ request, lightUrl, snippetLanguage, batchFilter }) => {
+export const CodeView = ({ request, lightUrl, snippetLanguage, batchFilter, searchText }) => {
   const [isRequestBodyExpanded, setIsRequestBodyExpanded] = useState(false);
   const [isBatchExecutionExpanded, setIsBatchExecutionExpanded] = useState(false);
   const [hoveredButton, setHoveredButton] = useState(null);
 
   const isRest = snippetLanguage === "rest";
+
+  // When the Search box has a query, highlight matches in syntax-highlighted
+  // blocks via a custom renderer; plain-text renderers get the raw query.
+  const query = (searchText || "").trim();
+  const highlightRenderer = query ? buildHighlightRenderer(query) : undefined;
 
   let urlStyle = atomOneDark;
   if (lightUrl) {
@@ -280,6 +360,7 @@ export const CodeView = ({ request, lightUrl, snippetLanguage, batchFilter }) =>
                 language="jboss-cli"
                 style={urlStyle}
                 wrapLongLines={true}
+                renderer={highlightRenderer}
                 customStyle={{
                   borderRadius: "8px",
                   padding: "12px",
@@ -436,6 +517,7 @@ export const CodeView = ({ request, lightUrl, snippetLanguage, batchFilter }) =>
                               language="json"
                               style={atomOneDark}
                               wrapLongLines={true}
+                              renderer={highlightRenderer}
                               customStyle={{
                                 borderRadius: "6px",
                                 padding: "8px",
@@ -499,6 +581,7 @@ export const CodeView = ({ request, lightUrl, snippetLanguage, batchFilter }) =>
                           language="json"
                           style={atomOneDark}
                           wrapLongLines={true}
+                          renderer={highlightRenderer}
                           customStyle={{
                             borderRadius: "8px",
                             padding: "12px",
@@ -560,6 +643,7 @@ export const CodeView = ({ request, lightUrl, snippetLanguage, batchFilter }) =>
                           language="json"
                           style={atomOneDark}
                           wrapLongLines={true}
+                          renderer={highlightRenderer}
                           customStyle={{
                             borderRadius: "8px",
                             padding: "12px",
@@ -649,7 +733,7 @@ export const CodeView = ({ request, lightUrl, snippetLanguage, batchFilter }) =>
             {isBatchExecutionExpanded && (
               <div style={{ position: "relative" }}>
                 <pre className="gxr-code-block">
-                  <ColoredCode code={request.code} />
+                  <ColoredCode code={request.code} query={query} />
                 </pre>
                 <IconButton
                   iconProps={{ iconName: "Copy" }}
@@ -707,7 +791,7 @@ export const CodeView = ({ request, lightUrl, snippetLanguage, batchFilter }) =>
             </span>
             <div style={{ position: "relative", flex: 1 }}>
               <div className="gxr-rest-url">
-                <ColoredUrl url={request.code} />
+                <ColoredUrl url={request.code} query={query} />
               </div>
               <IconButton
                 iconProps={{ iconName: "Copy" }}
@@ -749,7 +833,7 @@ export const CodeView = ({ request, lightUrl, snippetLanguage, batchFilter }) =>
         ) : (
           <div style={{ position: "relative" }}>
             <pre className="gxr-code-block">
-              <ColoredCode code={request.code} />
+              <ColoredCode code={request.code} query={query} />
             </pre>
             <IconButton
               iconProps={{ iconName: "Copy" }}
@@ -823,7 +907,7 @@ export const CodeView = ({ request, lightUrl, snippetLanguage, batchFilter }) =>
                   </span>
                   <div style={{ position: "relative", flex: 1 }}>
                     <div className="gxr-rest-url">
-                      <ColoredUrl url={snippet.code} />
+                      <ColoredUrl url={snippet.code} query={query} />
                     </div>
                     <IconButton
                       iconProps={{ iconName: "Copy" }}
@@ -874,7 +958,7 @@ export const CodeView = ({ request, lightUrl, snippetLanguage, batchFilter }) =>
               </div>
               <div style={{ position: "relative" }}>
                 <pre className="gxr-code-block">
-                  <ColoredCode code={snippet.code} />
+                  <ColoredCode code={snippet.code} query={query} />
                 </pre>
                 <IconButton
                   iconProps={{ iconName: "Copy" }}

--- a/src/devtools/DevTools.css
+++ b/src/devtools/DevTools.css
@@ -35,6 +35,15 @@ td, th {
   border-bottom: 1px solid #edebe9;
 }
 
+/* Search match highlight — reads on both the light URL theme and the dark
+   JSON/code blocks. */
+.gxr-search-hit {
+  background: #ffe58f;
+  color: #1b1b1b;
+  border-radius: 2px;
+  padding: 0 1px;
+}
+
 .gxr-filter-header {
   display: flex;
   align-items: center;

--- a/src/devtools/DevTools.js
+++ b/src/devtools/DevTools.js
@@ -29,7 +29,8 @@ const options = [
   { key: "javascript", text: "JavaScript", fileExt: "js" },
   { key: "java", text: "Java", fileExt: "java" },
   { key: "objective-c", text: "Objective-C", fileExt: "c" },
-  { key: "go", text: "Go", fileExt: "go" },  
+  { key: "go", text: "Go", fileExt: "go" },
+  { key: "terraform", text: "Terraform (msgraph)", fileExt: "tf" },
 ];
 
 class DevTools extends React.Component {

--- a/src/devtools/DevTools.js
+++ b/src/devtools/DevTools.js
@@ -10,6 +10,7 @@ import { Dropdown } from "@fluentui/react/lib/Dropdown";
 import { Toggle } from "@fluentui/react/lib/Toggle";
 import { IconButton } from "@fluentui/react/lib/Button";
 import { TooltipHost } from "@fluentui/react/lib/Tooltip";
+import { MessageBar, MessageBarType } from "@fluentui/react/lib/MessageBar";
 import { SearchBox } from "@fluentui/react/lib/SearchBox";
 import DevToolsCommandBar from "../components/DevToolsCommandBar";
 import { Layer } from "@fluentui/react/lib/Layer";
@@ -39,11 +40,15 @@ class DevTools extends React.Component {
     // Load ultraXRayMode from localStorage, default to false
     const savedUltraXRayMode = localStorage.getItem('graphxray-ultraXRayMode');
     const ultraXRayMode = savedUltraXRayMode ? JSON.parse(savedUltraXRayMode) : false;
-    
+
+    const savedExperimentalCreateFromGet = localStorage.getItem('graphxray-experimentalCreateFromGet');
+    const experimentalCreateFromGet = savedExperimentalCreateFromGet ? JSON.parse(savedExperimentalCreateFromGet) : false;
+
     this.state = {
       stack: [],
       snippetLanguage: "powershell",
       ultraXRayMode: ultraXRayMode,
+      experimentalCreateFromGet: experimentalCreateFromGet,
       filterText: "",
       selectedMethods: new Set(),
       selectedResources: new Set(),
@@ -123,7 +128,7 @@ class DevTools extends React.Component {
         request,
         version,
         harEntry,
-        { preferLocalPowerShell: true }
+        { preferLocalPowerShell: true, experimentalCreateFromGet: this.state.experimentalCreateFromGet }
       );
       console.log("DevTools - local getCodeView returned:", localCodeView);
 
@@ -145,7 +150,7 @@ class DevTools extends React.Component {
         request,
         version,
         harEntry,
-        { devxOnly: true }
+        { devxOnly: true, experimentalCreateFromGet: this.state.experimentalCreateFromGet }
       );
       console.log("DevTools - server getCodeView returned:", serverCodeView);
 
@@ -190,7 +195,8 @@ class DevTools extends React.Component {
       this.state.snippetLanguage,
       request,
       version,
-      harEntry
+      harEntry,
+      { experimentalCreateFromGet: this.state.experimentalCreateFromGet }
     );
     console.log("DevTools - getCodeView returned:", codeView);
     if (codeView) {
@@ -413,6 +419,12 @@ class DevTools extends React.Component {
     localStorage.setItem('graphxray-ultraXRayMode', JSON.stringify(checked));
     this.clearStack(); // Clear the stack when toggling mode
   };
+
+  onExperimentalCreateFromGetToggle = (e, checked) => {
+    this.setState({ experimentalCreateFromGet: checked });
+    localStorage.setItem('graphxray-experimentalCreateFromGet', JSON.stringify(checked));
+    this.clearStack();
+  };
   render() {
     return (
       <div className="App" style={{ fontSize: FontSizes.size12 }}>
@@ -506,7 +518,63 @@ class DevTools extends React.Component {
                   />
                 </TooltipHost>
               </div>
+
+              {this.state.snippetLanguage === "terraform" && (
+                <div style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "8px",
+                  marginBottom: "8px"
+                }}>
+                  <Toggle
+                    label="Create resource from GET response"
+                    checked={this.state.experimentalCreateFromGet}
+                    onChange={this.onExperimentalCreateFromGetToggle}
+                    onText="On"
+                    offText="Off"
+                    styles={{
+                      root: { marginBottom: 0 },
+                      label: { fontWeight: "600" }
+                    }}
+                  />
+                  <TooltipHost
+                    content="When enabled, GET responses are used to render msgraph_resource blocks. Read-only and server-generated fields are stripped heuristically, so review every attribute before applying. When disabled, only POST/PUT/PATCH requests produce terraform snippets."
+                    styles={{
+                      root: {
+                        display: "inline-block"
+                      }
+                    }}
+                  >
+                    <IconButton
+                      iconProps={{ iconName: "Info" }}
+                      title="Experimental create from get information"
+                      styles={{
+                        root: {
+                          minWidth: "24px",
+                          width: "24px",
+                          height: "24px",
+                          color: "#666",
+                          backgroundColor: "transparent",
+                          border: "1px solid #ccc",
+                          borderRadius: "50%"
+                        },
+                        rootHovered: {
+                          backgroundColor: "rgba(0, 0, 0, 0.05)",
+                          color: "#333"
+                        }
+                      }}
+                    />
+                  </TooltipHost>
+                </div>
+              )}
             </div>
+            {this.state.snippetLanguage === "terraform" && this.state.experimentalCreateFromGet && (
+              <div style={{ marginTop: "12px" }}>
+                <MessageBar messageBarType={MessageBarType.warning} isMultiline={true}>
+                  <strong>Experimental:</strong> Terraform blocks are derived from observed GET responses. Read-only and server-generated fields are stripped heuristically &mdash; review every attribute (including required values, defaults, and odata discriminators) before running <code>terraform apply</code>.
+                </MessageBar>
+              </div>
+            )}
           </div>
           {this.state.stack && this.state.stack.length > 0 && (() => {
             const methodCounts = this.getUniqueMethods();

--- a/src/devtools/DevTools.js
+++ b/src/devtools/DevTools.js
@@ -50,10 +50,12 @@ class DevTools extends React.Component {
       ultraXRayMode: ultraXRayMode,
       experimentalCreateFromGet: experimentalCreateFromGet,
       filterText: "",
+      searchText: "",
       selectedMethods: new Set(),
       selectedResources: new Set(),
       selectedDomains: new Set(),
       filtersExpanded: true,
+      searchExpanded: false,
     };
   }
 
@@ -316,15 +318,37 @@ class DevTools extends React.Component {
     return item.batchCodeSnippets.map((s) => (s.method || "").toUpperCase()).filter(Boolean);
   }
 
+  // Full-content searchable text for an item: URL + bodies + generated code,
+  // plus each batch sub-request's url/code. Used by the "Search" box so a GUID
+  // (objectId/appId) is found wherever it appears, not just in the URL.
+  static getSearchableText(item) {
+    const parts = [
+      item.displayRequestUrl,
+      item.requestBody,
+      item.responseContent,
+      item.code,
+    ];
+    if (DevTools.isBatchItem(item)) {
+      item.batchCodeSnippets.forEach((s) => {
+        parts.push(s.url, s.code);
+      });
+    }
+    return parts.filter(Boolean).join("\n").toLowerCase();
+  }
+
   getFilteredStack() {
-    const { stack, filterText, selectedMethods, selectedResources, selectedDomains } = this.state;
+    const { stack, filterText, searchText, selectedMethods, selectedResources, selectedDomains } = this.state;
     const search = filterText.toLowerCase();
+    const contentSearch = searchText.trim().toLowerCase();
     return stack.filter((item) => {
       if (search && !item.displayRequestUrl.toLowerCase().includes(search)) {
         // Also search inside batch sub-request URLs
         if (!DevTools.isBatchItem(item) || !item.batchCodeSnippets.some((s) => s.url.toLowerCase().includes(search))) {
           return false;
         }
+      }
+      if (contentSearch && !DevTools.getSearchableText(item).includes(contentSearch)) {
+        return false;
       }
       if (selectedMethods.size > 0) {
         if (DevTools.isBatchItem(item)) {
@@ -610,10 +634,10 @@ class DevTools extends React.Component {
                       ? `${totalCount} requests`
                       : `${filteredCount} of ${totalCount} requests`}
                   </span>
-                  {(this.state.filterText || this.state.selectedMethods.size > 0 || this.state.selectedResources.size > 0 || this.state.selectedDomains.size > 0) && (
+                  {(this.state.filterText || this.state.searchText || this.state.selectedMethods.size > 0 || this.state.selectedResources.size > 0 || this.state.selectedDomains.size > 0) && (
                     <button
                       className="gxr-pill gxr-pill-clear"
-                      onClick={() => this.setState({ filterText: "", selectedMethods: new Set(), selectedResources: new Set(), selectedDomains: new Set() })}
+                      onClick={() => this.setState({ filterText: "", searchText: "", selectedMethods: new Set(), selectedResources: new Set(), selectedDomains: new Set() })}
                     >
                       Clear filters
                     </button>
@@ -678,6 +702,40 @@ class DevTools extends React.Component {
                 )}
               </div>
 
+              {/* Search bar — full-content search (URL + bodies + code), sibling to Filters */}
+              <div className="gxr-filter-bar">
+                <div className="gxr-filter-header">
+                  <button
+                    className="gxr-filter-toggle"
+                    onClick={() => this.setState((prev) => ({ searchExpanded: !prev.searchExpanded }))}
+                    title={this.state.searchExpanded ? "Collapse search" : "Expand search"}
+                  >
+                    <span className={`gxr-filter-chevron ${this.state.searchExpanded ? "gxr-filter-chevron-open" : ""}`}>&#9656;</span>
+                    Search
+                  </button>
+                  {this.state.searchText && (
+                    <button
+                      className="gxr-pill gxr-pill-clear"
+                      onClick={() => this.setState({ searchText: "" })}
+                    >
+                      Clear search
+                    </button>
+                  )}
+                </div>
+
+                {this.state.searchExpanded && (
+                  <div className="gxr-filter-body">
+                    <SearchBox
+                      placeholder="Search GUID, objectId, appId, any text..."
+                      value={this.state.searchText}
+                      onChange={(_, val) => this.setState({ searchText: val || "" })}
+                      onClear={() => this.setState({ searchText: "" })}
+                      styles={{ root: { maxWidth: 360, minWidth: 220 } }}
+                    />
+                  </div>
+                )}
+              </div>
+
               {filteredStack.map((request, index) => (
                 <div
                   key={index}
@@ -693,6 +751,7 @@ class DevTools extends React.Component {
                     lightUrl={true}
                     snippetLanguage={this.state.snippetLanguage}
                     batchFilter={this.getBatchFilter()}
+                    searchText={this.state.searchText}
                   ></CodeView>
                 </div>
               ))}

--- a/src/options/Options.test.js
+++ b/src/options/Options.test.js
@@ -2,8 +2,14 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import Options from "./Options";
 
-test("renders learn react link", () => {
+test("renders the help heading", () => {
   render(<Options />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  expect(
+    screen.getByText(/Viewing the Graph call stack trace/i)
+  ).toBeInTheDocument();
+});
+
+test("renders the step by step guide", () => {
+  render(<Options />);
+  expect(screen.getByText(/Step by step guide/i)).toBeInTheDocument();
 });


### PR DESCRIPTION
## Problem
Generate Terraform msgraph resources and transform GET to Create

## Solution
As an Entra ID Administrator, typically, we start to create/configure Entra ID in the portal. Based on that configuration, with the extended Graph X-Ray, we can generate MS Graph resources based on the assumption that Microsoft Graph API GET is similar to POST. 
Also in the AI era, we can ask an AI agent to check the generated resource and fix it based on the MS Documentation for Graph API (via MCP).

## Assumption
In cases like Conditional Access Policy, Tenant Configuration, like security configuration and Entra External ID for customers with User Flows, we want to export the current Entra ID configuration as a base to Entra as code Terraform solution. The current PR extended that possibility for Terraform.

## Visualisation
<img width="1268" height="975" alt="image" src="https://github.com/user-attachments/assets/8ca5ed2a-aeaf-4e36-8c53-ccf53103c421" />
